### PR TITLE
Add conversion methods to ZKUtility

### DIFF
--- a/src/ZKUtility.js
+++ b/src/ZKUtility.js
@@ -36,6 +36,22 @@ class ZKUtility {
      */
     isValidEthAddress = RNZumoKit.isValidEthAddress;
 
+    ethToGwei(eth) {
+        return eth * 1000000000;
+    }
+
+    gweiToEth(gwei) {
+        return gwei / 1000000000;
+    }
+
+    ethToWei(eth) {
+        return eth / 1000000000000000000;
+    }
+
+    weiToEth(wei) {
+        return wei * 1000000000000000000;
+    }
+
 }
 
 export default new ZKUtility();


### PR DESCRIPTION
Adds three new methods to `ZKUtility`:

- `ethToGwei(eth)`
- `gweiToEth(gwei)`
- `ethToWei(eth)`
- `weiToEth(wei)`

Please figure any inaccurate powers, and let me know if it needs changing before merge.

Alternatively, we could use the [`ethereumjs-units` library](https://github.com/ethereumjs/ethereumjs-units).