### PR TITLE
Define timestamp format for Moment

### DIFF
--- a/src/models/Transaction.js
+++ b/src/models/Transaction.js
@@ -114,7 +114,7 @@ export default class Transaction {
         if(json.hash) this.hash = json.hash;
         if(json.timestamp) {
             this.timestamp = json.timestamp;
-            this.time = new Moment(json.timestamp);
+            this.time = new Moment(json.timestamp, 'X');
         }
         if(json.status) this.status = json.status;
         if(json.value) this.value = parseFloat(json.value);


### PR DESCRIPTION
I finally found the root cause of the date bug. Moment should be parsing unix time correctly, however it was presuming the format provided was `ddmmyyyy` (or something similar). This PR forces it to always use Unix time.

Additional fix will be implemented on ZumoPay to handle timezones as that's done outside of the ZumoKit library.