### PR TITLE
Propagate ZumoKitError to RN wrapper

### DIFF
--- a/RNZumoKit.podspec
+++ b/RNZumoKit.podspec
@@ -1,7 +1,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "RNZumoKit"
-  s.version      = "1.0.0"
+  s.version      = "1.4.0-beta.1"
   s.summary      = "RNZumoKit"
   s.description  = <<-DESC
                   RNZumoKit
@@ -10,12 +10,12 @@ Pod::Spec.new do |s|
   s.license      = "MIT"
   s.author       = { "author" => "Zumo" }
   s.platform     = :ios, "7.0"
-  s.source       = { :git => "ssh://github.com/dlabs/zumokit-react-native.git", :tag => "master" }
+  s.source       = { :git => "ssh://github.com/dlabs/zumokit-react-native.git", :tag => "#{s.version}" }
   s.source_files  = "ios/**/*.{h,m,mm}"
   s.requires_arc = true
 
 
   s.dependency "React"
-  s.dependency "ZumoKit", "~> 1.3.0-beta.3"
+  s.dependency "ZumoKit", "#{s.version}"
 
 end

--- a/ios/RNZumoKit.m
+++ b/ios/RNZumoKit.m
@@ -3,6 +3,8 @@
 #import "ZumoKitManager.h"
 #import <ZumoKit/ZumoKit.h>
 
+NSString *const ZumoKitDomain = @"money.zumo.zumokit";
+
 @implementation RNZumoKit
 
 bool hasListeners;
@@ -22,6 +24,20 @@ bool hasListeners;
     return NO;
 }
 
+- (void)rejectPromiseWithZKZumoKitError:(RCTPromiseRejectBlock)reject error:(ZKZumoKitError *)error
+{
+    reject(error.errorCode, error.errorMessage, [[NSError alloc] initWithDomain:ZumoKitDomain
+                                                                           code:code
+                                                                        userInfo:@{@"errorType": error.errorType}
+                                                                    ]);
+}
+
+- (void)rejectPromiseWithString:(NSString *)errorMessage
+{
+    reject("unknown", errorMessage, NULL);
+}
+
+
 RCT_EXPORT_MODULE()
 
 # pragma mark - Events
@@ -40,11 +56,11 @@ RCT_EXPORT_MODULE()
 
 
 - (void)update:(nonnull ZKState *)state {
-    
+
     if(!hasListeners) return;
-        
+
     [self sendEventWithName:@"StateChanged" body:[self mapState:state]];
-    
+
 }
 
 
@@ -52,46 +68,44 @@ RCT_EXPORT_MODULE()
 
 RCT_EXPORT_METHOD(init:(NSString *)apiKey apiRoot:(NSString *)apiRoot myRoot:(NSString *)myRoot txServiceUrl:(NSString *)txServiceUrl)
 {
-    
+
     [[ZumoKitManager sharedManager] setStateListener:self];
-    
+
     [[ZumoKitManager sharedManager]
      initializeWithTxServiceUrl:txServiceUrl
      apiKey:apiKey
      apiRoot:apiRoot
      myRoot:myRoot];
-    
+
 }
 
 RCT_EXPORT_METHOD(auth:(NSString *)token headers:(NSDictionary *)headers resolver:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseRejectBlock)reject)
 {
-    
+
     @try {
-        
+
         [[ZumoKitManager sharedManager]
-         authenticateWithToken:token
-         headers:headers
-         completionHandler:^(bool success, short errorCode, NSString * _Nullable errorMessage, ZKUser * _Nullable user) {
-            
-            if(user) {
-                
+            authenticateWithToken:token
+            headers:headers
+            completionHandler:^(bool success, ZKZumoKitError * _Nullable error, ZKUser * _Nullable user) {
+
+            if(success) {
                 resolve(@{
                     @"id": [user getId],
                     @"hasWallet": @([user hasWallet])
                 });
-                
             } else {
-                reject(@"error", errorMessage, NULL);
+                [self rejectPromiseWithZKZumoKitError:reject error:error];
             }
-            
+
         }];
-        
+
     } @catch (NSException *exception) {
-        
+
         reject(exception.name, exception.description, NULL);
-        
+
     }
-    
+
 }
 
 # pragma mark - Wallet Management
@@ -99,117 +113,117 @@ RCT_EXPORT_METHOD(auth:(NSString *)token headers:(NSDictionary *)headers resolve
 
 RCT_EXPORT_METHOD(createWallet:(NSString *)mnemonic password:(NSString *)password resolver:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseRejectBlock)reject)
 {
-    
+
     @try {
-    
-        [[ZumoKitManager sharedManager] createWallet:mnemonic password:password completionHandler:^(BOOL success) {
-            
+
+        [[ZumoKitManager sharedManager] createWallet:mnemonic password:password completionHandler:^(bool success, ZKZumoKitError * _Nullable error, ZKWallet * _Nullable wallet) {
+
             if(success) {
                 resolve(@(success));
             } else {
-                reject(@"error", @"Could not create wallet", NULL);
+                [self rejectPromiseWithZKZumoKitError:reject error:error];
             }
-            
+
         }];
-        
+
     } @catch (NSException *exception) {
-        
+
         reject(exception.name, exception.description, NULL);
-        
+
     }
-    
+
 }
 
 RCT_EXPORT_METHOD(revealMnemonic:(NSString *)password resolver:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseRejectBlock)reject)
 {
-    
+
     @try {
-        
-        [[ZumoKitManager sharedManager] revealMnemonic:password completionHandler:^(bool success, NSString * _Nullable errorName, NSString * _Nullable errorMessage, NSString * _Nullable mnemonic) {
-            
+
+        [[ZumoKitManager sharedManager] revealMnemonic:password completionHandler:^(bool success, ZKZumoKitError * _Nullable error, NSString * _Nullable mnemonic) {
+
             if(success) {
                 resolve(mnemonic);
             } else {
-                reject(@"error", @"Could not retrieve mnemonic", NULL);
+                [self rejectPromiseWithZKZumoKitError:reject error:error];
             }
-            
+
         }];
-        
+
     } @catch (NSException *exception) {
-        
+
         reject(exception.name, exception.description, NULL);
-        
+
     }
-    
+
 }
 
 RCT_EXPORT_METHOD(unlockWallet:(NSString *)password resolver:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseRejectBlock)reject)
 {
-    
+
     @try {
-    
-        [[ZumoKitManager sharedManager] unlockWallet:password completionHandler:^(BOOL success) {
-            
+
+        [[ZumoKitManager sharedManager] unlockWallet:password completionHandler:^(bool success, ZKZumoKitError * _Nullable error, ZKWallet * _Nullable wallet) {
+
             if(success) {
                 resolve(@(success));
             } else {
-                reject(@"error", @"Could not unlock wallet", NULL);
+                [self rejectPromiseWithZKZumoKitError:reject error:error];
             }
-            
+
         }];
-        
+
     } @catch (NSException *exception) {
-        
+
         reject(exception.name, exception.description, NULL);
-        
+
     }
-    
+
 }
 
 RCT_EXPORT_METHOD(sendEthTransaction:(NSString *)accountId gasPrice:(NSString *)gasPrice gasLimit:(NSString *)gasLimit to:(NSString *)to value:(NSString *)value data:(NSString *)data nonce:(NSString *)nonce resolver:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseRejectBlock)reject)
 {
-    
+
     @try {
-    
-        [[ZumoKitManager sharedManager] sendEthTransaction:accountId gasPrice:gasPrice gasLimit:gasLimit to:to value:value data:data nonce:nonce ? @([nonce integerValue]) : NULL completionHandler:^(bool success, NSString * _Nullable errorName, NSString * _Nullable errorMessage, ZKTransaction * _Nullable transaction) {
-            
+
+        [[ZumoKitManager sharedManager] sendEthTransaction:accountId gasPrice:gasPrice gasLimit:gasLimit to:to value:value data:data nonce:nonce ? @([nonce integerValue]) : NULL completionHandler:^(bool success, ZKZumoKitError * _Nullable error, ZKTransaction * _Nullable transaction) {
+
             if(transaction) {
                 resolve([self mapTransaction:transaction]);
             } else {
-                reject(@"error", @"Problem sending transaction", NULL);
+                [self rejectPromiseWithZKZumoKitError:reject error:error];
             }
-            
+
         }];
-    
+
     } @catch (NSException *exception) {
-           
+
        reject(exception.name, exception.description, NULL);
-       
+
    }
-    
+
 }
 
 RCT_EXPORT_METHOD(sendBtcTransaction:(NSString *)accountId changeAccountId:(NSString *)changeAccountId to:(NSString *)to value:(NSString *)value feeRate:(NSString *)feeRate resolver:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseRejectBlock)reject)
 {
-    
+
     @try {
-        
-        [[ZumoKitManager sharedManager] sendBtcTransaction:accountId changeAccountId:changeAccountId to:to value:value feeRate:feeRate completionHandler:^(bool success, NSString * _Nullable errorName, NSString * _Nullable errorMessage, ZKTransaction * _Nullable transaction) {
-           
+
+        [[ZumoKitManager sharedManager] sendBtcTransaction:accountId changeAccountId:changeAccountId to:to value:value feeRate:feeRate completionHandler:^(bool success, ZKZumoKitError * _Nullable error, ZKTransaction * _Nullable transaction) {
+
             if(transaction) {
                 resolve([self mapTransaction:transaction]);
             } else {
-                reject(@"error", @"Problem sending transaction", NULL);
+                [self rejectPromiseWithZKZumoKitError:reject error:error];
             }
-            
+
         }];
-        
+
     } @catch (NSException *exception) {
-        
+
         reject(exception.name, exception.description, NULL);
-        
+
     }
-    
+
 }
 
 
@@ -217,37 +231,37 @@ RCT_EXPORT_METHOD(sendBtcTransaction:(NSString *)accountId changeAccountId:(NSSt
 
 
 RCT_EXPORT_METHOD(isRecoveryMnemonic:(NSString *)mnemonic resolver:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseRejectBlock)reject) {
-    
+
     @try {
         BOOL validation = [[ZumoKitManager sharedManager] isRecoveryMnemonic:mnemonic];
         resolve(@(validation));
     } @catch (NSException *exception) {
         reject(exception.name, exception.description, NULL);
     }
-    
+
 }
 
 RCT_EXPORT_METHOD(recoverWallet:(NSString *)mnemonic password:(NSString *)password resolver:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseRejectBlock)reject)
 {
-    
+
     @try {
-    
+
         [[ZumoKitManager sharedManager] recoverWallet:mnemonic password:password completionHandler:^(BOOL success) {
-            
+
             if(success) {
                 resolve(@(success));
             } else {
-                reject(@"error", @"Could not recover wallet", NULL);
+                [self rejectPromiseWithZKZumoKitError:reject error:error];
             }
-            
+
         }];
-        
+
     } @catch (NSException *exception) {
-        
+
         reject(exception.name, exception.description, NULL);
-        
+
     }
-    
+
 }
 
 
@@ -266,7 +280,7 @@ RCT_EXPORT_METHOD(isValidBtcAddress:(NSString *)address network:(NSString *)netw
     if([network isEqualToString:@"TESTNET"]) {
         networkType = ZKNetworkTypeTESTNET;
     }
-    
+
     BOOL isValid = [[ZumoKitManager sharedManager] isValidBtcAddress:address network:networkType];
     resolve(@(isValid));
 }
@@ -322,22 +336,22 @@ RCT_EXPORT_METHOD(clear:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseReje
 #pragma mark - Mapping
 
 - (NSDictionary *)mapState:(ZKState *)state {
-    
+
     return @{
         @"accounts": [self mapAccounts:[state accounts]],
         @"transactions": [self mapTransactions:[state transactions]],
         @"exchangeRates": [state exchangeRates],
         @"feeRates": [self mapFeeRates:[state feeRates]]
     };
-    
+
 }
 
 - (NSArray<NSDictionary *> *)mapAccounts:(NSArray<ZKAccount *>*)accounts {
- 
+
     NSMutableArray<NSDictionary *> *mapped = [[NSMutableArray alloc] init];
-    
+
     [accounts enumerateObjectsUsingBlock:^(ZKAccount * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
-        
+
         [mapped addObject:@{
             @"id": [obj id],
             @"path": [obj path],
@@ -349,38 +363,38 @@ RCT_EXPORT_METHOD(clear:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseReje
         }];
 
     }];
-    
+
     return mapped;
-    
+
 }
 
 - (NSDictionary *)mapTransaction:(ZKTransaction *)transaction {
-    
+
     NSString *status;
-           
+
     switch ([transaction status]) {
        case ZKTransactionStatusCONFIRMED:
            status = @"CONFIRMED";
            break;
-           
+
        case ZKTransactionStatusFAILED:
            status = @"FAILED";
            break;
-            
+
         case ZKTransactionStatusRESUBMITTED:
             status = @"RESUBMITTED";
             break;
-            
+
         case ZKTransactionStatusCANCELLED:
             status = @"CANCELLED";
             break;
-           
+
        default:
            status = @"PENDING";
            break;
-           
+
     }
-    
+
     NSMutableDictionary *dict = [@{
         @"id": [transaction id],
         @"txHash": [transaction txHash],
@@ -394,7 +408,7 @@ RCT_EXPORT_METHOD(clear:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseReje
         @"cost": [transaction cost],
         @"timestamp": @([transaction timestamp])
     } mutableCopy];
-    
+
     if([transaction chainId]) dict[@"chainId"] = [transaction chainId];
     if([transaction nonce]) dict[@"nonce"] = [transaction nonce];
     if([transaction fromUserId]) dict[@"fromUserId"] = [transaction fromUserId];
@@ -405,14 +419,14 @@ RCT_EXPORT_METHOD(clear:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseReje
     if([transaction submittedAt]) dict[@"submittedAt"] = [transaction submittedAt];
     if([transaction confirmedAt]) dict[@"confirmedAt"] = [transaction confirmedAt];
     if([transaction fiatValue]) dict[@"fiatValue"] = [transaction fiatValue];
-    
+
     return dict;
 }
 
 - (NSDictionary *)mapFeeRates:(NSDictionary<NSString *, ZKFeeRates *>*)feeRates {
-    
+
     NSMutableDictionary *dict = [[NSMutableDictionary alloc] init];
-    
+
     [feeRates enumerateKeysAndObjectsUsingBlock:^(NSString * _Nonnull key, ZKFeeRates * _Nonnull obj, BOOL * _Nonnull stop) {
         dict[key] = @{
             @"slow": [obj slow],
@@ -420,20 +434,20 @@ RCT_EXPORT_METHOD(clear:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseReje
             @"fast": [obj fast]
         };
     }];
-    
+
     return dict;
 }
 
 - (NSArray<NSDictionary *> *)mapTransactions:(NSArray<ZKTransaction *>*)transactions {
-    
+
     NSMutableArray<NSDictionary *> *mapped = [[NSMutableArray alloc] init];
-    
+
     [transactions enumerateObjectsUsingBlock:^(ZKTransaction * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
         [mapped addObject:[self mapTransaction:obj]];
     }];
-    
+
     return mapped;
-    
+
 }
 
 

--- a/ios/ZumoKitManager.h
+++ b/ios/ZumoKitManager.h
@@ -13,7 +13,7 @@ NS_ASSUME_NONNULL_BEGIN
 
 @interface ZumoKitManager : NSObject
 
-@property (weak) id <ZKStateListener> stateListener;
+@property(weak) id<ZKStateListener> stateListener;
 
 + (ZumoKitManager *)sharedManager;
 
@@ -21,12 +21,11 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)authenticateWithToken:(NSString *)token headers:(NSDictionary *)headers completionHandler:(_Nonnull AuthCompletionBlock)completionHandler;
 
+#pragma mark - Wallet Management
 
-# pragma mark - Wallet Management
+- (void)createWallet:(NSString *)mnemonic password:(NSString *)password completionHandler:(_Nonnull WalletCompletionBlock)completionHandler;
 
-- (void)createWallet:(NSString *)mnemonic password:(NSString *)password completionHandler:(void (^)(BOOL success))completionHandler;
-
-- (void)unlockWallet:(NSString *)password completionHandler:(void (^)(BOOL success))completionHandler;
+- (void)unlockWallet:(NSString *)password completionHandler:(_Nonnull WalletCompletionBlock)completionHandler;
 
 - (void)revealMnemonic:(NSString *)password completionHandler:(_Nonnull MnemonicCompletionBlock)completionHandler;
 
@@ -34,15 +33,13 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (void)sendBtcTransaction:(NSString *)accountId changeAccountId:(NSString *)changeAccountId to:(NSString *)to value:(NSString *)value feeRate:(NSString *)feeRate completionHandler:(_Nonnull SendTransactionCompletionBlock)completionHandler;
 
-
-# pragma mark - Wallet Recovery
+#pragma mark - Wallet Recovery
 
 - (BOOL)isRecoveryMnemonic:(NSString *)mnemonic;
 
-- (void)recoverWallet:(NSString *)mnemonic password:(NSString *)password completionHandler:(void (^)(BOOL success))completionHandler;
+- (void)recoverWallet:(NSString *)mnemonic password:(NSString *)password completionHandler:(_Nonnull WalletCompletionBlock)completionHandler;
 
-
-# pragma mark - Utility
+#pragma mark - Utility
 
 - (BOOL)isValidEthAddress:(NSString *)address;
 

--- a/ios/ZumoKitManager.mm
+++ b/ios/ZumoKitManager.mm
@@ -21,18 +21,18 @@
 @implementation ZumoKitManager
 
 NSException *zumoKitNotInitializedException = [NSException
-                                               exceptionWithName:@"ZumoKitNotInitialized"
-                                               reason:@"ZumoKit has not been initialized"
+                                               exceptionWithName:@"zumokit_not_initialized"
+                                               reason:@"ZumoKit has not been initialized."
                                                userInfo:nil];
 
 NSException *userNotAuthenticatedException = [NSException
-                                              exceptionWithName:@"UserNotAuthenticated"
-                                              reason:@"A user has not been authenticated"
+                                              exceptionWithName:@"user_not_authenticated"
+                                              reason:@"A user has not been authenticated."
                                               userInfo:nil];
 
 NSException *walletNotFoundException = [NSException
-                                        exceptionWithName:@"WalletNotFound"
-                                        reason:@"The user doesn't seem to have wallet"
+                                        exceptionWithName:@"wallet_not_found"
+                                        reason:@"The user doesn't seem to have a wallet."
                                         userInfo:nil];
 
 + (id)sharedManager {
@@ -46,73 +46,73 @@ NSException *walletNotFoundException = [NSException
 
 
 - (void)initializeWithTxServiceUrl:(NSString *)txServiceUrl apiKey:(NSString *)apiKey apiRoot:(NSString *)apiRoot myRoot:(NSString *)myRoot {
-    
+
     _zumoKit =  [[ZumoKit alloc] initWithTxServiceUrl:txServiceUrl
                                                apiKey:apiKey
                                               apiRoot:apiRoot
                                                myRoot:myRoot
             ];
-    
+
     [_zumoKit addStateListener:_stateListener];
-    
+
 }
 
 - (void)authenticateWithToken:(NSString *)token headers:(NSDictionary *)headers completionHandler:(AuthCompletionBlock)completionHandler {
-    
+
     if(! _zumoKit) @throw zumoKitNotInitializedException;
-    
-    [_zumoKit auth:token headers:headers completion:^(bool success, short errorCode, NSString * _Nullable errorMessage, ZKUser * _Nullable user) {
-        
+
+    [_zumoKit auth:token headers:headers completion:^(bool success, ZKZumoKitError * _Nullable error, ZKUser * _Nullable user) {
+
         self->_user = user;
-        
-        completionHandler(success, errorCode, errorMessage, user);
-        
+
+        completionHandler(success, error, user);
+
     }];
-    
+
 }
 
 # pragma mark - Wallet Management
 
-- (void)createWallet:(NSString *)mnemonic password:(NSString *)password completionHandler:(void (^)(BOOL))completionHandler {
-    
+- (void)createWallet:(NSString *)mnemonic password:(NSString *)password completionHandler:(WalletCompletionBlock)completionHandler {
+
     if(! _user) @throw userNotAuthenticatedException;
-    
-    [_user createWallet:mnemonic password:password completion:^(bool success, NSString * _Nullable errorName, NSString * _Nullable errorMessage, ZKWallet * _Nullable wallet) {
-       
+
+    [_user createWallet:mnemonic password:password completion:^(bool success, ZKZumoKitError * _Nullable error, ZKWallet * _Nullable wallet) {
+
         self->_wallet = wallet;
-        
-        completionHandler(success);
-                
+
+        completionHandler(success, error, wallet);
+
     }];
-    
+
 }
 
 
-- (void)unlockWallet:(NSString *)password completionHandler:(void (^)(BOOL))completionHandler {
- 
+- (void)unlockWallet:(NSString *)password completionHandler:(WalletCompletionBlock)completionHandler {
+
     if(! _user) @throw userNotAuthenticatedException;
-    
-    [_user unlockWallet:password completion:^(bool success, NSString * _Nullable errorName, NSString * _Nullable errorMessage, ZKWallet * _Nullable wallet) {
-        
+
+    [_user unlockWallet:password completion:^(bool success, ZKZumoKitError * _Nullable error, ZKWallet * _Nullable wallet) {
+
         self->_wallet = wallet;
-        
-        completionHandler(success);
-        
+
+        completionHandler(success, error, wallet);
+
     }];
-    
+
 }
 
 - (void)revealMnemonic:(NSString *)password completionHandler:(MnemonicCompletionBlock)completionHandler {
-    
+
     if(! _user) @throw userNotAuthenticatedException;
     [_user revealMnemonic:password completion:completionHandler];
 
 }
 
 - (void)sendEthTransaction:(NSString *)accountId gasPrice:(NSString *)gasPrice gasLimit:(NSString *)gasLimit to:(NSString *)to value:(NSString *)value data:(NSString *)data nonce:(NSNumber *)nonce completionHandler:(SendTransactionCompletionBlock)completionHandler {
-    
+
     if(! _wallet) @throw walletNotFoundException;
-    
+
     [_wallet
      sendEthTransaction:accountId
      gasPrice:gasPrice
@@ -123,98 +123,98 @@ NSException *walletNotFoundException = [NSException
      nonce:NULL
      completion:completionHandler
      ];
-    
+
 }
 
 - (void)sendBtcTransaction:(NSString *)accountId changeAccountId:(NSString *)changeAccountId to:(NSString *)to value:(NSString *)value feeRate:(NSString *)feeRate completionHandler:(SendTransactionCompletionBlock)completionHandler {
-    
+
     if(! _wallet) @throw walletNotFoundException;
-    
+
     [_wallet
      sendBtcTransaction:accountId
      changeAccountId:changeAccountId
      to:to value:value
      feeRate:feeRate
      completion:completionHandler];
-    
+
 }
 
 # pragma mark - Wallet Recovery
 
 - (BOOL)isRecoveryMnemonic:(NSString *)mnemonic {
-    
+
     if(! _user) @throw userNotAuthenticatedException;
     return [_user isRecoveryMnemonic:mnemonic];
-    
+
 }
 
-- (void)recoverWallet:(NSString *)mnemonic password:(NSString *)password completionHandler:(void (^)(BOOL))completionHandler {
-    
+- (void)recoverWallet:(NSString *)mnemonic password:(NSString *)password completionHandler:(WalletCompletionBlock)completionHandler {
+
     if(! _user) @throw userNotAuthenticatedException;
-    
-    [_user recoverWallet:mnemonic password:password completion:^(bool success, NSString * _Nullable errorName, NSString * _Nullable errorMessage, ZKWallet * _Nullable wallet) {
-       
+
+    [_user recoverWallet:mnemonic password:password completion:^(bool success, ZKZumoKitError * _Nullable error, ZKWallet * _Nullable wallet) {
+
         self->_wallet = wallet;
-        
-        completionHandler(success);
-                
+
+        completionHandler(success, error, wallet);
+
     }];
-    
+
 }
 
 # pragma mark - Utility
 
 - (BOOL)isValidEthAddress:(NSString *)address {
     if(! _zumoKit) @throw zumoKitNotInitializedException;
-    
+
     return [[_zumoKit utils] isValidEthAddress:address];
 }
 
 - (BOOL)isValidBtcAddress:(NSString *)address network:(ZKNetworkType)network {
     if(! _zumoKit) @throw zumoKitNotInitializedException;
-    
+
     return [[_zumoKit utils] isValidBtcAddress:address network:network];
 }
 
 - (NSString *)ethToGwei:(NSString *)eth {
     if(! _zumoKit) @throw zumoKitNotInitializedException;
-    
+
     return [[_zumoKit utils] ethToGwei:eth];
 }
 
 - (NSString *)gweiToEth:(NSString *)gwei {
     if(! _zumoKit) @throw zumoKitNotInitializedException;
-    
+
     return [[_zumoKit utils] gweiToEth:gwei];
 }
 
 - (NSString *)ethToWei:(NSString *)eth {
     if(! _zumoKit) @throw zumoKitNotInitializedException;
-    
+
     return [[_zumoKit utils] ethToWei:eth];
 }
 
 - (NSString *)weiToEth:(NSString *)wei {
     if(! _zumoKit) @throw zumoKitNotInitializedException;
-    
+
     return [[_zumoKit utils] weiToEth:wei];
 }
 
 - (NSString *)generateMnemonic:(int)wordLength {
     if(! _zumoKit) @throw zumoKitNotInitializedException;
-    
+
     return [[_zumoKit utils] generateMnemonic:wordLength];
 }
 
 - (NSString *)maxSpendableEth:(NSString *)accountId gasPrice:(NSString *)gasPrice gasLimit:(NSString *)gasLimit {
     if(! _wallet) @throw walletNotFoundException;
-    
+
     return [_wallet maxSpendableEth:accountId gasPrice:gasPrice gasLimit:gasPrice];
 }
 
 - (NSString *)maxSpendableBtc:(NSString *)accountId to:(NSString *)to feeRate:(NSString *)feeRate {
     if(! _wallet) @throw walletNotFoundException;
-    
+
     return [_wallet maxSpendableBtc:accountId to:to feeRate:feeRate];
 }
 


### PR DESCRIPTION
ZumoKit React Native SDK did not propagate errors from Android and iOS SDKs, instead returning generic error messages. 

This PR adds support for handling ZumoKitError object and propagates this error in the following format to React Native SDK user, ie. you @deanhet.

```
{
  code: "invalid_password",
  message: "Incorrect password provided. Please try again.",
  userInfo: 
    {
      "errorType": "wallet_error"
    }
}
```  

I have figured out a way to make a middleware that transforms this nested error into flat `{ type, code, message }` format but this has to be properly tested, therefore I will be including this in next week's release. Once this is done, you will be able to handle all errors from Zumo API and ZumoKit SDK in the same manner.

Moreover, you will be able to know which errors should only be logged to Sentry and which errors should be displayed to the end user based on error type (api_connection_error, api_error, authentication_error, wallet_error, transaction_error, invalid_request_error, rate_limit_error invalid_argument_error).

