### PR TITLE
Expose historical exchange rates in iOS wrapper

### DIFF
--- a/src/ZumoKit.js
+++ b/src/ZumoKit.js
@@ -97,6 +97,16 @@ class ZumoKit {
     }
 
     /**
+     * Get historical exchange rates
+     *
+     * @returns ¯\_(ツ)_/¯
+     * @memberof ZumoKit
+     */
+    async getHistoricalExchangeRates() {
+        return RNZumoKit.getHistoricalExchangeRates();
+    }
+
+    /**
      * Adds a new listener for state updates.
      *
      * @param {function} callback


### PR DESCRIPTION
Returns an object of the form:
```
{
  hour: [ { exchangeRate }, ... ],
  day: ...
}
```

Exchange rate object is the same as the one found in state, ie:
```
{
  ETH: {
    BTC: { value, validTo, timestamp }
  },
  ...
}
```