### PR TITLE
Feature/exchange ios

### DIFF
--- a/ios/RNZumoKit.m
+++ b/ios/RNZumoKit.m
@@ -543,6 +543,7 @@ RCT_EXPORT_METHOD(clear:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseReje
     return @{
         @"accounts": [self mapAccounts:[state accounts]],
         @"transactions": [self mapTransactions:[state transactions]],
+        @"exchanges": [self mapExchanges:[state exchanges]],
         @"exchangeRates": [self mapExchangeRatesDict:[state exchangeRates]],
         @"exchangeFees": [self mapExchangeFeesDict:[state exchangeFees]],
         @"feeRates": [self mapFeeRates:[state feeRates]]
@@ -711,6 +712,28 @@ RCT_EXPORT_METHOD(clear:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseReje
     return dict;
 }
 
+- (NSDictionary *)mapExchange:(ZKExchange *)exchange {
+    return @{
+         @"id": [exchange id],
+         @"status": [exchange status],
+         @"depositCurrency": [exchange depositCurrency],
+         @"depositAccountId": [exchange depositAccountId],
+         @"depositTransactionId": [exchange depositTransactionId],
+         @"withdrawCurrency": [exchange withdrawCurrency],
+         @"withdrawAccountId": [exchange withdrawAccountId],
+         @"withdrawTransactionId": [exchange withdrawTransactionId] ? [exchange withdrawTransactionId] : [NSNull null],
+         @"amount": [exchange amount],
+         @"depositFee": [exchange depositFee] ? [exchange depositFee] : [NSNull null],
+         @"returnAmount": [exchange returnAmount],
+         @"exchangeFee": [exchange exchangeFee],
+         @"withdrawFee": [exchange withdrawFee],
+         @"exchangeRate": [self mapExchangeRate:[exchange exchangeRate]],
+         @"exchangeFees": [self mapExchangeFees:[exchange exchangeFees]],
+         @"submittedAt": [exchange submittedAt],
+         @"confirmedAt": [exchange confirmedAt] ? [exchange confirmedAt] : [NSNull null],
+    };
+}
+
 - (NSDictionary *)mapFeeRates:(NSDictionary<NSString *, ZKFeeRates *>*)feeRates {
 
     NSMutableDictionary *dict = [[NSMutableDictionary alloc] init];
@@ -733,6 +756,7 @@ RCT_EXPORT_METHOD(clear:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseReje
         @"depositCurrency": [exchangeRates depositCurrency],
         @"withdrawCurrency": [exchangeRates withdrawCurrency],
         @"value": [exchangeRates value],
+        @"validTo": [NSNumber numberWithLongLong:[exchangeRates validTo]],
         @"timestamp": [NSNumber numberWithLongLong:[exchangeRates timestamp]]
     };
 }
@@ -833,6 +857,18 @@ RCT_EXPORT_METHOD(clear:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseReje
 
     [transactions enumerateObjectsUsingBlock:^(ZKTransaction * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
         [mapped addObject:[self mapTransaction:obj]];
+    }];
+
+    return mapped;
+
+}
+
+- (NSArray<NSDictionary *> *)mapExchanges:(NSArray<ZKExchange *>*)exchanges {
+
+    NSMutableArray<NSDictionary *> *mapped = [[NSMutableArray alloc] init];
+
+    [exchanges enumerateObjectsUsingBlock:^(ZKExchange * _Nonnull obj, NSUInteger idx, BOOL * _Nonnull stop) {
+        [mapped addObject:[self mapExchange:obj]];
     }];
 
     return mapped;

--- a/src/ZumoKit.js
+++ b/src/ZumoKit.js
@@ -1,6 +1,6 @@
 import { NativeModules, NativeEventEmitter } from 'react-native';
 import User from './models/User';
-import Transaction from './models/Transaction';
+import Parser from './util/Parser';
 import { tryCatchProxy } from './ZKErrorProxy';
 
 const { RNZumoKit } = NativeModules;
@@ -22,7 +22,10 @@ class ZumoKit {
         authenticatedUser: null,
         accounts: [],
         transactions: [],
-        feeRates: null
+        exchanges: [],
+        feeRates: null,
+        exchangeRates: null,
+        exchangeFees: null
     };
 
     /**
@@ -68,10 +71,14 @@ class ZumoKit {
             console.log('ZumoKitStateChanged');
             console.log(state);
 
-            if(state.accounts) this.state.accounts = state.accounts;
-            if(state.transactions) this.state.transactions = state.transactions.map((json) => new Transaction(json));
-            if(state.exchangeRates) this.state.exchangeRates = state.exchangeRates;
-            if(state.feeRates) this.state.feeRates = state.feeRates;
+            if(state.accounts) this.state.accounts = Parser.parseAccounts(state.accounts);
+            if(state.transactions) this.state.transactions = Parser.parseTransactions(state.transactions);
+            if(state.exchanges) this.state.exchanges = Parser.parseExchanges(state.exchanges);
+            if(state.exchangeRates) this.state.exchangeRates = Parser.parseExchangeRates(state.exchangeRates);
+            if(state.feeRates) this.state.feeRates = Parser.parseFeeRates(state.feeRates);
+            if(state.exchangeFees) this.state.exchangeFees = Parser.parseExchangeFees(state.exchangeFees);
+
+            console.log(this.state);
 
             this._notifyStateListeners();
 

--- a/src/models/Account.js
+++ b/src/models/Account.js
@@ -52,19 +52,20 @@ export default class Account {
     chainId;
 
     /**
-     * Number of transactions on the account to-date; used to sign outgoing transactions
+     * JSON representation of Account object
      *
      * @memberof Account
      */
-    nonce;
+    json;
 
     constructor(json) {
+        this.json = json;
         if(json.id) this.id = json.id;
         if(json.path) this.path = json.path;
         if(json.symbol) this.symbol = json.symbol;
         if(json.coin) this.coin = json.coin;
         if(json.address) this.address = json.address;
-        if(json.balance) this.balance = new Decimal(json.balance);
+        if(json.balance) this.balance = json.balance;
         if(json.network) this.network = json.network;
         if(json.type) this.type = json.type;
         if(json.nonce) this.nonce = json.nonce;

--- a/src/models/Account.js
+++ b/src/models/Account.js
@@ -52,6 +52,13 @@ export default class Account {
     chainId;
 
     /**
+     * Number of transactions on the account to-date; used to sign outgoing transactions
+     *
+     * @memberof Account
+     */
+    nonce;
+
+    /**
      * JSON representation of Account object
      *
      * @memberof Account

--- a/src/models/ComposedExchange.js
+++ b/src/models/ComposedExchange.js
@@ -1,0 +1,23 @@
+import Account from './Account';
+import ExchangeRate from './ExchangeRate';
+import ExchangeFees from './ExchangeFees';
+import { Decimal } from 'decimal.js';
+
+export default class ComposedExchange {
+
+    constructor(json) {
+        this.json = json;
+        this.signedTransaction = json.signedTransaction;
+        this.depositAccount = new Account(json.depositAccount);
+        this.withdrawAccount = new Account(json.withdrawAccount);
+        this.exchangeRate = new ExchangeRate(json.exchangeRate);
+        this.exchangeFees = new ExchangeFees(json.exchangeFees);
+        this.exchangeAddress = json.exchangeAddress;
+        this.value = new Decimal(json.value);
+        this.returnValue = new Decimal(json.returnValue);
+        this.depositFee = new Decimal(json.depositFee);
+        this.exchangeFee = new Decimal(json.exchangeFee);
+        this.withdrawFee = new Decimal(json.withdrawFee);
+    }
+
+}

--- a/src/models/ComposedTransaction.js
+++ b/src/models/ComposedTransaction.js
@@ -1,8 +1,7 @@
 import Account from './Account';
 import { Decimal } from 'decimal.js';
-import { tryCatchProxy } from '../ZKErrorProxy';
 
-class ComposedTransaction {
+export default class ComposedTransaction {
 
     /**
      * Signed transaction
@@ -60,11 +59,9 @@ class ComposedTransaction {
         this.signedTransaction = json.signedTransaction;
         this.account = new Account(json.account);
         this.destination = json.destination;
-        this.value = (json.value) ? new Decimal(json.value) : new Decimal(0);
+        this.value = (json.value) ? new Decimal(json.value) : null;
         this.data = json.data;
         this.fee = new Decimal(json.fee);
     }
 
 }
-
-export default (tryCatchProxy(ComposedTransaction))

--- a/src/models/Exchange.js
+++ b/src/models/Exchange.js
@@ -1,0 +1,31 @@
+import { Decimal } from 'decimal.js';
+import ExchangeRate from './ExchangeRate';
+import ExchangeFees from './ExchangeFees';
+import { tryCatchProxy } from '../ZKErrorProxy';
+
+class Exchange {
+
+    constructor(json) {
+        this.json = json;
+        this.id = json.id;
+        this.status = json.status;
+        this.depositCurrency = json.depositCurrency;
+        this.depositAccountId = json.depositAccountId;
+        this.depositTransactionId = json.depositTransactionId;
+        this.withdrawCurrency = json.withdrawCurrency;
+        this.withdrawAccountId = json.withdrawAccountId;
+        this.withdrawTransactionId = json.withdrawTransactionId;
+        this.amount = new Decimal(json.amount);
+        this.depositFee = json.depositFee ? new Decimal(json.depositFee) : null;
+        this.returnAmount = new Decimal(json.returnAmount);
+        this.exchangeFee = new Decimal(json.exchangeFee);
+        this.withdrawFee = new Decimal(json.withdrawFee);
+        this.exchangeRate = new ExchangeRate(json.exchangeRate);
+        this.exchangeFees = new ExchangeFees(json.exchangeFees);
+        this.submittedAt = json.submittedAt;
+        this.confirmedAt = json.confirmedAt;
+    }
+
+}
+
+export default (tryCatchProxy(Exchange))

--- a/src/models/ExchangeFees.js
+++ b/src/models/ExchangeFees.js
@@ -1,0 +1,72 @@
+import { Decimal } from 'decimal.js';
+
+export default class ExchangeFees {
+
+    /**
+     * ID of the exchange rate group
+     *
+     * @memberof ExchangeFees
+     */
+    id;
+
+    /**
+     * Deposit currency
+     *
+     * @memberof ExchangeFees
+     */
+    depositCurrrency;
+
+    /**
+     * Withdraw currency
+     *
+     * @memberof ExchangeFees
+     */
+    withdrawCurrency;
+
+    /**
+     * Fee rate that will be used to deposit funds from user to exchange
+     *
+     * @memberof ExchangeFees
+     */
+    depositFeeRate;
+
+    /**
+     * Exchange fee rate
+     *
+     * @memberof ExchangeFees
+     */
+    feeRate;
+
+    /**
+     * Fee of the return transaction from exchange to user
+     *
+     * @memberof ExchangeFees
+     */
+    withdrawFee;
+
+    /**
+     * Timestamp
+     *
+     * @memberof ExchangeFees
+     */
+    timestamp;
+
+    /**
+     * JSON representation of ExchangeFees object
+     *
+     * @memberof ExchangeFees
+     */
+    json;
+
+    constructor(json) {
+        this.json = json;
+        this.id = json.id;
+        this.depositCurrency = json.depositCurrency;
+        this.withdrawCurrency = json.withdrawCurrency;
+        this.feeRate = new Decimal(json.feeRate);
+        this.withdrawFee = new Decimal(json.feeRate);
+        this.validTo = json.validTo;
+        this.timestamp = json.timestamp;
+    }
+
+}

--- a/src/models/ExchangeRate.js
+++ b/src/models/ExchangeRate.js
@@ -1,0 +1,64 @@
+import { Decimal } from 'decimal.js';
+
+export default class ExchangeRate {
+
+    /**
+     * ID of the exchange rate group
+     *
+     * @memberof ExchangeRate
+     */
+    id;
+
+    /**
+     * Deposit currency
+     *
+     * @memberof ExchangeRate
+     */
+    depositCurrrency;
+
+    /**
+     * Withdraw currency
+     *
+     * @memberof ExchangeRate
+     */
+    withdrawCurrency;
+
+    /**
+     * Exchange rate value
+     *
+     * @memberof ExchangeRate
+     */
+    value;
+
+    /**
+     * Rate valid to timestamp
+     *
+     * @memberof ExchangeRate
+     */
+    validTo;
+
+    /**
+     * Timestamp
+     *
+     * @memberof ExchangeRate
+     */
+    timestamp;
+
+    /**
+     * JSON representation of ExchangeRate object
+     *
+     * @memberof ExchangeRate
+     */
+    json;
+
+    constructor(json) {
+        this.json = json;
+        this.id = json.id;
+        this.depositCurrency = json.depositCurrency;
+        this.withdrawCurrency = json.withdrawCurrency;
+        this.value = json.value;
+        this.validTo = json.validTo;
+        this.timestamp = json.timestamp;
+    }
+
+}

--- a/src/models/FeeRates.js
+++ b/src/models/FeeRates.js
@@ -1,0 +1,72 @@
+import { Decimal } from 'decimal.js';
+
+export default class FeeRates {
+
+    /**
+     * Slow fee rate
+     *
+     * @memberof FeeRates
+     */
+    slow;
+
+    /**
+     * Average fee rate
+     *
+     * @memberof FeeRates
+     */
+    average;
+
+    /**
+     * Fast fee rate
+     *
+     * @memberof FeeRates
+     */
+    fast;
+
+    /**
+     * Estimated slow confirmation time in hours
+     *
+     * @memberof FeeRates
+     */
+    slow_time;
+
+    /**
+     * Estimated average confirmation time in hours
+     *
+     * @memberof FeeRates
+     */
+    average_time;
+
+    /**
+     * Estimated fast confirmation time in hours
+     *
+     * @memberof FeeRates
+     */
+    fast_time;
+
+    /**
+     * Source of fees data
+     *
+     * @memberof FeeRates
+     */
+    source;
+
+        /**
+     * JSON representation of Account object
+     *
+     * @memberof Account
+     */
+    json;
+
+    constructor(json) {
+        this.json = json;
+        if(json.slow) this.slow = json.slow;
+        if(json.average) this.average = json.average;
+        if(json.fast) this.fast = json.fast;
+        if(json.slow_time) this.slow_time = json.slow_time;
+        if(json.average_time) this.average_time = json.average_time;
+        if(json.fast_time) this.fast_time = json.fast_time;
+        if(json.source) this.source = json.source;
+    }
+
+}

--- a/src/models/Transaction.js
+++ b/src/models/Transaction.js
@@ -1,5 +1,4 @@
 import { NativeModules, NativeEventEmitter } from 'react-native';
-import ZumoKit from '../ZumoKit';
 import Moment from 'moment-timezone';
 import { Decimal } from 'decimal.js';
 const { RNZumoKit } = NativeModules;
@@ -187,8 +186,15 @@ class Transaction {
      */
     _transactionListener;
 
-    constructor(json) {
+    /**
+     * JSON representation of Account object
+     *
+     * @memberof Account
+     */
+    json;
 
+    constructor(json) {
+        this.json = json;
         if(json.id) this.id = json.id;
         if(json.type) this.type = json.type;
         if(json.direction) this.direction = json.direction;

--- a/src/models/Wallet.js
+++ b/src/models/Wallet.js
@@ -1,6 +1,8 @@
 import { NativeModules } from 'react-native';
 import Transaction from './Transaction';
 import ComposedTransaction from './ComposedTransaction';
+import Exchange from './Exchange';
+import ComposedExchange from './ComposedExchange';
 const { RNZumoKit } = NativeModules;
 import { tryCatchProxy } from '../ZKErrorProxy';
 
@@ -67,6 +69,29 @@ class Wallet {
         );
 
         return new ComposedTransaction(json);
+    }
+
+    /**
+     * Composes a new exchange
+     *
+     * @param {string} depositAccountId
+     * @param {string} withdrawAccountId
+     * @param {ExchangeRate} exchangeRate
+     * @param {ExchangeFees} exchangeFees
+     * @param {Decimal} value
+     * @returns
+     * @memberof ComposedExchange
+     */
+    async composeExchange(depositAccountId, withdrawAccountId, exchangeRate, exchangeFees, value) {
+        const json = await RNZumoKit.composeExchange(
+            depositAccountId,
+            withdrawAccountId,
+            exchangeRate.json,
+            exchangeFees.json,
+            value.toString()
+        );
+
+        return new ComposedExchange(json);
     }
 
     /**

--- a/src/util/Parser.js
+++ b/src/util/Parser.js
@@ -1,0 +1,65 @@
+import Account from '../models/Account'
+import Transaction from '../models/Transaction'
+import Exchange from '../models/Exchange'
+import ExchangeRate from '../models/ExchangeRate'
+import ExchangeFees from '../models/ExchangeFees';
+import FeeRates from '../models/FeeRates';
+
+export default class Parser {
+
+  static parseAccounts(accounts) {
+    return accounts.map((json) => new Account(json));
+  }
+
+  static parseTransactions(transactions) {
+    return transactions.map((json) => new Transaction(json));
+  }
+
+  static parseExchanges(exchanges) {
+    return exchanges.map((json) => new Exchange(json));
+  }
+
+  static parseFeeRates(feeRatesMap) {
+    for (const currency in feeRatesMap) {
+      feeRatesMap[currency] = new FeeRates(feeRatesMap[currency])
+    }
+    return feeRatesMap
+  }
+
+
+  static parseExchangeRates(exchangeRateMap) {
+    for (const depositCurrency in exchangeRateMap) {
+      for (const withdrawCurrency in exchangeRateMap[depositCurrency]) {
+        exchangeRateMap[depositCurrency][withdrawCurrency] =
+          new ExchangeRate(exchangeRateMap[depositCurrency][withdrawCurrency])
+      }
+    }
+    return exchangeRateMap
+  }
+
+  static parseExchangeFees(exchangeFeesMap) {
+    for (const depositCurrency in exchangeFeesMap) {
+      for (const withdrawCurrency in exchangeFeesMap[depositCurrency]) {
+        exchangeFeesMap[depositCurrency][withdrawCurrency] =
+          new ExchangeFees(exchangeFeesMap[depositCurrency][withdrawCurrency])
+      }
+    }
+    return exchangeFeesMap
+  }
+
+  static parseHistoricalExchangeRates(exchangeRateMap) {
+    for (const timeInterval in exchangeRateMap) {
+      let obj1 = exchangeRateMap[timeInterval]
+      for (const depositCurrency in obj1) {
+        let obj2 = obj1[depositCurrency]
+        for (const withdrawCurrency in obj2) {
+          let array = obj2[withdrawCurrency]
+          exchangeRateMap[timeInterval][depositCurrency][withdrawCurrency] =
+            array.map((json) => new ExchangeRate(json))
+        }
+      }
+    }
+    return exchangeRateMap
+  }
+
+}


### PR DESCRIPTION
- Adds exchanges and exchangeFees to state
- Adds composeExchange to Wallet object. Example usage:
```
    const user = await ZumoKit.getUser(token)
    const depositAccount = await user.getAccount("ETH", "RINKEBY", "STANDARD");
    const withdrawAccount = await user.getAccount("BTC", "TESTNET", "COMPATIBILITY");
    const wallet = await user.unlockWallet("givemeeth")
    const exchangeRate = ZumoKit.state.exchangeRates[depositAccount.symbol][withdrawAccount.symbol];
    const exchangeFees = ZumoKit.state.exchangeFees[depositAccount.symbol][withdrawAccount.symbol];

    const composedExchange = await wallet.composeExchange(
      depositAccount.id,
      withdrawAccount.id,
      exchangeRate,
      exchangeFees,
      new Decimal("0.01"));
    console.log(composedExchange);
```

SubmitExchange method will follow in next PR. I just want to unblock you.

PS: There are no breaking changes.