### PR TITLE
Release/1.7.0

### DIFF
--- a/RNZumoKit.podspec
+++ b/RNZumoKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "RNZumoKit"
-  s.version      = "1.6.0-beta.22"
+  s.version      = "1.7.0-beta.2"
   s.summary      = "RNZumoKit"
   s.description  = <<-DESC
                   RNZumoKit

--- a/android/.settings/org.eclipse.buildship.core.prefs
+++ b/android/.settings/org.eclipse.buildship.core.prefs
@@ -1,2 +1,13 @@
+arguments=
+auto.sync=false
+build.scans.enabled=false
+connection.gradle.distribution=GRADLE_DISTRIBUTION(WRAPPER)
 connection.project.dir=
 eclipse.preferences.version=1
+gradle.user.home=
+java.home=/Library/Java/JavaVirtualMachines/jdk1.8.0_191.jdk/Contents/Home
+jvm.arguments=
+offline.mode=false
+override.workspace.settings=true
+show.console.view=true
+show.executions.view=true

--- a/android/src/main/java/com/zumokit/reactnative/RNZumoKitModule.java
+++ b/android/src/main/java/com/zumokit/reactnative/RNZumoKitModule.java
@@ -707,22 +707,6 @@ public class RNZumoKitModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void maxSpendableEth(String accountId, String gasPrice, String gasLimit, Promise promise) {
-
-    String max = this.wallet.maxSpendableEth(accountId, gasPrice, gasLimit);
-    promise.resolve(max);
-
-  }
-
-  @ReactMethod
-  public void maxSpendableBtc(String accountId, String to, String feeRate, Promise promise) {
-
-    String max = this.wallet.maxSpendableBtc(accountId, to, feeRate);
-    promise.resolve(max);
-
-  }
-
-  @ReactMethod
   public void clear(Promise promise) {
 
     this.user = null;

--- a/android/src/main/java/com/zumokit/reactnative/RNZumoKitModule.java
+++ b/android/src/main/java/com/zumokit/reactnative/RNZumoKitModule.java
@@ -1143,7 +1143,7 @@ public class RNZumoKitModule extends ReactContextBaseJavaModule {
     AccountType type = AccountType.valueOf(map.getString("type"));
     byte version = Integer.valueOf(map.getInt("version")).byteValue();
 
-    return new Account(accountId, path, symbol, coin, address, balance, nonce, network, type, version);
+    return new Account(accountId, path, symbol, coin, address, balance, nonce, network, type, null, version);
   }
 
   public static ExchangeRate unboxExchangeRate(ReadableMap map) {

--- a/android/src/main/java/com/zumokit/reactnative/RNZumoKitModule.java
+++ b/android/src/main/java/com/zumokit/reactnative/RNZumoKitModule.java
@@ -109,7 +109,7 @@ public class RNZumoKitModule extends ReactContextBaseJavaModule {
   // - Authentication
 
   @ReactMethod
-  public void getUser(String token, Promise promise) {
+  public void getUser(String tokenSet, Promise promise) {
 
     if(this.zumoKit == null) {
       rejectPromise(promise, "ZumoKit not initialized.");
@@ -118,7 +118,7 @@ public class RNZumoKitModule extends ReactContextBaseJavaModule {
 
     RNZumoKitModule module = this;
 
-    this.zumoKit.getUser(token, new UserCallback() {
+    this.zumoKit.getUser(tokenSet, new UserCallback() {
 
       @Override
       public void onError(Exception error) {
@@ -318,7 +318,7 @@ public class RNZumoKitModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void composeEthTransaction(String accountId, String gasPrice, String gasLimit, String to, String value, String data, String nonce, Promise promise) {
+  public void composeEthTransaction(String accountId, String gasPrice, String gasLimit, String to, String value, String data, String nonce, Boolean sendMax, Promise promise) {
 
     if(this.wallet == null) {
       rejectPromise(promise, "Wallet not found.");
@@ -330,7 +330,7 @@ public class RNZumoKitModule extends ReactContextBaseJavaModule {
       nonceValue = Long.parseLong(nonce);
     }
 
-    this.wallet.composeEthTransaction(accountId, gasPrice, gasLimit, to, value, data, nonceValue, new ComposeTransactionCallback() {
+    this.wallet.composeEthTransaction(accountId, gasPrice, gasLimit, to, value, data, nonceValue, sendMax, new ComposeTransactionCallback() {
 
       @Override
       public void onError(Exception error) {
@@ -348,14 +348,14 @@ public class RNZumoKitModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void composeBtcTransaction(String accountId, String changeAccountId, String to, String value, String feeRate, Promise promise) {
+  public void composeBtcTransaction(String accountId, String changeAccountId, String to, String value, String feeRate, Boolean sendMax, Promise promise) {
 
     if(this.wallet == null) {
       rejectPromise(promise, "Wallet not found.");
       return;
     }
 
-    this.wallet.composeBtcTransaction(accountId, changeAccountId, to, value, feeRate, new ComposeTransactionCallback() {
+    this.wallet.composeBtcTransaction(accountId, changeAccountId, to, value, feeRate, sendMax, new ComposeTransactionCallback() {
 
       @Override
       public void onError(Exception error) {
@@ -373,7 +373,7 @@ public class RNZumoKitModule extends ReactContextBaseJavaModule {
   }
 
   @ReactMethod
-  public void composeExchange(String fromAccountId, String toAccountId, ReadableMap exchangeRate, ReadableMap exchangeSettings, String amount, Promise promise) {
+  public void composeExchange(String fromAccountId, String toAccountId, ReadableMap exchangeRate, ReadableMap exchangeSettings, String amount, Boolean sendMax, Promise promise) {
     if(this.wallet == null) {
       rejectPromise(promise, "Wallet not found.");
       return;
@@ -382,7 +382,7 @@ public class RNZumoKitModule extends ReactContextBaseJavaModule {
     ExchangeRate rate = RNZumoKitModule.unboxExchangeRate(exchangeRate);
     ExchangeSettings settings = RNZumoKitModule.unboxExchangeSettings(exchangeSettings);
 
-    this.wallet.composeExchange(fromAccountId, toAccountId, rate, settings, amount, new ComposeExchangeCallback() {
+    this.wallet.composeExchange(fromAccountId, toAccountId, rate, settings, amount, sendMax, new ComposeExchangeCallback() {
       @Override
       public void onError(Exception e) {
         rejectPromise(promise, e);

--- a/ios/RNZumoKit.m
+++ b/ios/RNZumoKit.m
@@ -295,7 +295,7 @@ RCT_EXPORT_METHOD(composeBtcTransaction:(NSString *)accountId changeAccountId:(N
 
     @try {
 
-        [_wallet composeBtcTransaction:accountId changeAccountId:changeAccountId to:to value:value feeRate:feeRate completion:^(ZKComposedTransaction * _Nullable transaction, NSError * _Nullable error) {
+        [_wallet composeBtcTransaction:accountId changeAccountId:changeAccountId to:to value:value feeRate:feeRate sendMax:sendMax completion:^(ZKComposedTransaction * _Nullable transaction, NSError * _Nullable error) {
 
             if(error != nil) {
                 [self rejectPromiseWithNSError:reject error:error];
@@ -321,7 +321,7 @@ RCT_EXPORT_METHOD(composeExchange:(NSString *)depositAccountId withdrawAccountId
         ZKExchangeRate *rate = [self unboxExchangeRate:exchangeRate];
         ZKExchangeSettings *fees = [self unboxExchangeSettings:exchangeSettings];
 
-        [_wallet composeExchange:depositAccountId withdrawAccountId:withdrawAccountId exchangeRate:rate exchangeSettings:fees value:value completion:^(ZKComposedExchange * _Nullable exchange, NSError * _Nullable error) {
+        [_wallet composeExchange:depositAccountId withdrawAccountId:withdrawAccountId exchangeRate:rate exchangeSettings:fees value:value sendMax:sendMax completion:^(ZKComposedExchange * _Nullable exchange, NSError * _Nullable error) {
 
             if(error != nil) {
                 [self rejectPromiseWithNSError:reject error:error];

--- a/ios/RNZumoKit.m
+++ b/ios/RNZumoKit.m
@@ -498,18 +498,6 @@ RCT_EXPORT_METHOD(generateMnemonic:(int)wordLength resolver:(RCTPromiseResolveBl
     resolve(mnemonic);
 }
 
-RCT_EXPORT_METHOD(maxSpendableEth:(NSString *)accountId gasPrice:(NSString *)gasPrice gasLimit:(NSString *)gasLimit resolver:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseRejectBlock)reject)
-{
-    NSString *max = [_wallet maxSpendableEth:accountId gasPrice:gasPrice gasLimit:gasLimit];
-    resolve(max);
-}
-
-RCT_EXPORT_METHOD(maxSpendableBtc:(NSString *)accountId to:(NSString *)to feeRate:(NSString *)feeRate resolver:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseRejectBlock)reject)
-{
-    NSString *max = [_wallet maxSpendableBtc:accountId to:to feeRate:feeRate];
-    resolve(max);
-}
-
 RCT_EXPORT_METHOD(clear:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseRejectBlock)reject)
 {
     _user = NULL;

--- a/ios/RNZumoKit.m
+++ b/ios/RNZumoKit.m
@@ -100,12 +100,12 @@ RCT_EXPORT_METHOD(init:(NSString *)apiKey apiRoot:(NSString *)apiRoot txServiceU
 
 }
 
-RCT_EXPORT_METHOD(getUser:(NSString *)token resolver:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseRejectBlock)reject)
+RCT_EXPORT_METHOD(getUser:(NSString *)tokenSet resolver:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseRejectBlock)reject)
 {
 
     @try {
 
-        [_zumoKit getUser:token completion:^(ZKUser * _Nullable user, NSError * _Nullable error) {
+        [_zumoKit getUser:tokenSet completion:^(ZKUser * _Nullable user, NSError * _Nullable error) {
 
             if(error != nil) {
                 [self rejectPromiseWithNSError:reject error:error];
@@ -266,12 +266,12 @@ RCT_EXPORT_METHOD(submitTransaction:(NSDictionary *)composedTransactionData reso
 }
 
 
-RCT_EXPORT_METHOD(composeEthTransaction:(NSString *)accountId gasPrice:(NSString *)gasPrice gasLimit:(NSString *)gasLimit to:(NSString *)to value:(NSString *)value data:(NSString *)data nonce:(NSString *)nonce resolver:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseRejectBlock)reject)
+RCT_EXPORT_METHOD(composeEthTransaction:(NSString *)accountId gasPrice:(NSString *)gasPrice gasLimit:(NSString *)gasLimit to:(NSString *)to value:(NSString *)value data:(NSString *)data nonce:(NSString *)nonce sendMax:(BOOL)sendMax resolver:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseRejectBlock)reject)
 {
 
     @try {
 
-        [_wallet composeEthTransaction:accountId gasPrice:gasPrice gasLimit:gasLimit to:to value:value data:data nonce:nonce ? @([nonce integerValue]) : NULL completion:^(ZKComposedTransaction * _Nullable transaction, NSError * _Nullable error) {
+        [_wallet composeEthTransaction:accountId gasPrice:gasPrice gasLimit:gasLimit to:to value:value data:data nonce:nonce ? @([nonce integerValue]) : NULL sendMax:sendMax completion:^(ZKComposedTransaction * _Nullable transaction, NSError * _Nullable error) {
 
             if(error != nil) {
                 [self rejectPromiseWithNSError:reject error:error];
@@ -290,7 +290,7 @@ RCT_EXPORT_METHOD(composeEthTransaction:(NSString *)accountId gasPrice:(NSString
 
 }
 
-RCT_EXPORT_METHOD(composeBtcTransaction:(NSString *)accountId changeAccountId:(NSString *)changeAccountId to:(NSString *)to value:(NSString *)value feeRate:(NSString *)feeRate resolver:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseRejectBlock)reject)
+RCT_EXPORT_METHOD(composeBtcTransaction:(NSString *)accountId changeAccountId:(NSString *)changeAccountId to:(NSString *)to value:(NSString *)value feeRate:(NSString *)feeRate sendMax:(BOOL)sendMax resolver:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseRejectBlock)reject)
 {
 
     @try {
@@ -314,7 +314,7 @@ RCT_EXPORT_METHOD(composeBtcTransaction:(NSString *)accountId changeAccountId:(N
 
 }
 
-RCT_EXPORT_METHOD(composeExchange:(NSString *)depositAccountId withdrawAccountId:(NSString *)withdrawAccountId exchangeRate:(NSDictionary *)exchangeRate exchangeSettings:(NSDictionary *)exchangeSettings value:(NSString *)value resolver:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseRejectBlock)reject)
+RCT_EXPORT_METHOD(composeExchange:(NSString *)depositAccountId withdrawAccountId:(NSString *)withdrawAccountId exchangeRate:(NSDictionary *)exchangeRate exchangeSettings:(NSDictionary *)exchangeSettings value:(NSString *)value sendMax:(BOOL)sendMax resolver:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseRejectBlock)reject)
 {
 
     @try {

--- a/ios/RNZumoKit.m
+++ b/ios/RNZumoKit.m
@@ -920,7 +920,7 @@ RCT_EXPORT_METHOD(clear:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseReje
     ZKNetworkType accountNetwork = [self unboxNetworkType:accountData[@"network"]];
     ZKAccountType accountType = [self unboxAccountType:accountData[@"type"]];
 
-    return [[ZKAccount alloc] initWithId:accountId path:accountPath symbol:accountSymbol coin:accountCoin address:accountAddress balance:accountBalance nonce:accountNonce network:accountNetwork type:accountType version:accountVersion.charValue];
+    return [[ZKAccount alloc] initWithId:accountId path:accountPath symbol:accountSymbol coin:accountCoin address:accountAddress balance:accountBalance nonce:accountNonce network:accountNetwork type:accountType utxoPool:NULL version:accountVersion.charValue];
 }
 
 - (ZKExchangeRate *)unboxExchangeRate:(NSDictionary *)exchangeRate {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-zumo-kit",
-  "version": "1.6.0-beta.22",
+  "version": "1.7.0-beta.2",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/ZumoKit.js
+++ b/src/ZumoKit.js
@@ -70,12 +70,12 @@ class ZumoKit {
 
             console.log('ZumoKitStateChanged');
 
-            if(state.accounts) this.state.accounts = Parser.parseAccounts(state.accounts);
-            if(state.transactions) this.state.transactions = Parser.parseTransactions(state.transactions);
-            if(state.exchanges) this.state.exchanges = Parser.parseExchanges(state.exchanges);
-            if(state.exchangeRates) this.state.exchangeRates = Parser.parseExchangeRates(state.exchangeRates);
-            if(state.feeRates) this.state.feeRates = Parser.parseFeeRates(state.feeRates);
-            if(state.exchangeSettings) this.state.exchangeSettings = Parser.parseExchangeSettings(state.exchangeSettings);
+            if (state.accounts) this.state.accounts = Parser.parseAccounts(state.accounts);
+            if (state.transactions) this.state.transactions = Parser.parseTransactions(state.transactions);
+            if (state.exchanges) this.state.exchanges = Parser.parseExchanges(state.exchanges);
+            if (state.exchangeRates) this.state.exchangeRates = Parser.parseExchangeRates(state.exchangeRates);
+            if (state.feeRates) this.state.feeRates = Parser.parseFeeRates(state.feeRates);
+            if (state.exchangeSettings) this.state.exchangeSettings = Parser.parseExchangeSettings(state.exchangeSettings);
 
             console.log(this.state);
 
@@ -87,12 +87,12 @@ class ZumoKit {
     /**
      * Authenticates the user with ZumoKit.
      *
-     * @param {string} token
+     * @param {Object} tokenSet
      * @returns
      * @memberof ZumoKit
      */
-    async getUser(token) {
-        const json = await RNZumoKit.getUser(token);
+    async getUser(tokenSet) {
+        const json = await RNZumoKit.getUser(JSON.stringify(tokenSet));
         const user = new User(json);
 
         this.state.authenticatedUser = user;
@@ -120,7 +120,7 @@ class ZumoKit {
      * @memberof ZumoKit
      */
     addStateListener(callback) {
-        if(this._listeners.includes(callback)) return;
+        if (this._listeners.includes(callback)) return;
         this._listeners.push(callback);
         callback(this.state);
     }
@@ -133,7 +133,7 @@ class ZumoKit {
      * @memberof ZumoKit
      */
     removeStateListener(callback) {
-        if(!this._listeners.includes(callback)) return;
+        if (!this._listeners.includes(callback)) return;
         const index = this._listeners.indexOf(callback);
         this._listeners.splice(index, 1);
     }

--- a/src/models/Wallet.js
+++ b/src/models/Wallet.js
@@ -22,7 +22,7 @@ class Wallet {
      * @returns
      * @memberof Wallet
      */
-    async composeEthTransaction(accountId, gasPrice, gasLimit, destinationAddresss, amount, data, nonce, sendMax) {
+    async composeEthTransaction(accountId, gasPrice, gasLimit, destinationAddresss, amount, data, nonce, sendMax = false) {
         const json = await RNZumoKit.composeEthTransaction(
             accountId,
             '' + gasPrice,
@@ -49,7 +49,7 @@ class Wallet {
      * @returns
      * @memberof Wallet
      */
-    async composeBtcTransaction(accountId, changeAccountId, destinationAddresss, amount, feeRate, sendMax) {
+    async composeBtcTransaction(accountId, changeAccountId, destinationAddresss, amount, feeRate, sendMax = false) {
         const json = await RNZumoKit.composeBtcTransaction(
             accountId,
             changeAccountId,
@@ -87,7 +87,7 @@ class Wallet {
      * @returns
      * @memberof ComposedExchange
      */
-    async composeExchange(fromAccountId, toAccountId, exchangeRate, exchangeSettings, amount, sendMax) {
+    async composeExchange(fromAccountId, toAccountId, exchangeRate, exchangeSettings, amount, sendMax = false) {
         const json = await RNZumoKit.composeExchange(
             fromAccountId,
             toAccountId,

--- a/src/models/Wallet.js
+++ b/src/models/Wallet.js
@@ -18,18 +18,20 @@ class Wallet {
      * @param {string} amount
      * @param {string} data
      * @param {number} nonce
+     * @param {Boolean} sendMax
      * @returns
      * @memberof Wallet
      */
-    async composeEthTransaction(accountId, gasPrice, gasLimit, destinationAddresss, amount, data, nonce) {
+    async composeEthTransaction(accountId, gasPrice, gasLimit, destinationAddresss, amount, data, nonce, sendMax) {
         const json = await RNZumoKit.composeEthTransaction(
             accountId,
             '' + gasPrice,
             '' + gasLimit,
             destinationAddresss,
-            '' + amount,
+            (amount) ? '' + amount : null,
             data,
-            (nonce) ? '' + nonce : null
+            (nonce) ? '' + nonce : null,
+            sendMax
         );
 
         return new ComposedTransaction(json);
@@ -43,28 +45,30 @@ class Wallet {
      * @param {string} destinationAddresss
      * @param {string} amount
      * @param {string} feeRate
+     * @param {Boolean} sendMax
      * @returns
      * @memberof Wallet
      */
-    async composeBtcTransaction(accountId, changeAccountId, destinationAddresss, amount, feeRate) {
+    async composeBtcTransaction(accountId, changeAccountId, destinationAddresss, amount, feeRate, sendMax) {
         const json = await RNZumoKit.composeBtcTransaction(
             accountId,
             changeAccountId,
             destinationAddresss,
-            '' + amount,
-            '' + feeRate
+            (amount) ? '' + amount : null,
+            '' + feeRate,
+            sendMax
         );
 
         return new ComposedTransaction(json);
     }
 
-     /**
-     * Submits transaction to Transaction Service
-     *
-     * @param {ComposedTransaction} composedTransaction
-     * @returns {Transaction}
-     * @memberof Wallet
-     */
+    /**
+    * Submits transaction to Transaction Service
+    *
+    * @param {ComposedTransaction} composedTransaction
+    * @returns {Transaction}
+    * @memberof Wallet
+    */
     async submitTransaction(composedTransaction) {
         const json = await RNZumoKit.submitTransaction(composedTransaction.json);
 
@@ -79,16 +83,18 @@ class Wallet {
      * @param {ExchangeRate} exchangeRate
      * @param {ExchangeSettings} exchangeSettings
      * @param {Decimal} amount
+     * @param {Boolean} sendMax
      * @returns
      * @memberof ComposedExchange
      */
-    async composeExchange(fromAccountId, toAccountId, exchangeRate, exchangeSettings, amount) {
+    async composeExchange(fromAccountId, toAccountId, exchangeRate, exchangeSettings, amount, sendMax) {
         const json = await RNZumoKit.composeExchange(
             fromAccountId,
             toAccountId,
             exchangeRate.json,
             exchangeSettings.json,
-            amount.toString()
+            amount ? amount.toString() : null,
+            sendMax
         );
 
         return new ComposedExchange(json);
@@ -104,32 +110,6 @@ class Wallet {
     async submitExchange(composedExchange) {
         const json = await RNZumoKit.submitExchange(composedExchange.json);
         return new Exchange(json);
-    }
-
-    /**
-     * Returns the maxmimum amount of Ethereum that can be spent.
-     *
-     * @param {string} accountId
-     * @param {string} gasPrice
-     * @param {string} gasLimit
-     * @returns
-     * @memberof Wallet
-     */
-    async maxSpendableEth(accountId, gasPrice, gasLimit) {
-        return RNZumoKit.maxSpendableEth(accountId, gasPrice, gasLimit);
-    }
-
-    /**
-     * Returns the maximum amount of Bitcoin that can be spent.
-     *
-     * @param {string} accountId
-     * @param {string} to
-     * @param {string} feeRate
-     * @returns
-     * @memberof Wallet
-     */
-    async maxSpendableBtc(accountId, to, feeRate) {
-        return RNZumoKit.maxSpendableBtc(accountId, to, feeRate);
     }
 
 }


### PR DESCRIPTION
**BREAKING CHANGE**: Allow option to send maximum funds when composing transaction or exchange

sendMax boolean parameter has to be passed to compose transaction and exchange methods.

**BREAKING CHANGE**: Remove legacy max spendable methods

No more max spendable methods. If you want to know max spendable amount, just run compose methods with sendMax=true and read value from returned composed transaction/object.

**BREAKING CHANGE**: Use token set instead of token for user authentication

Currently, only user token was being passed to getUser method. In order for refresh token mechanism to work, entire token set has to be passed.

Under the hood changes:
- Implement refresh token mechanism
- Construct Bitcoin transaction in SDK
- Update Bitcoin Core version to latest stable version (0.20.0)
- Add unit test coverage report build target