### PR TITLE
Bump SDK version

### DIFF
--- a/RNZumoKit.podspec
+++ b/RNZumoKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "RNZumoKit"
-  s.version      = "2.0.0-alpha.7"
+  s.version      = "2.0.0-alpha.8"
   s.summary      = "RNZumoKit"
   s.description  = <<-DESC
                   RNZumoKit

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-zumo-kit",
-  "version": "2.0.0-alpha.7",
+  "version": "2.0.0-alpha.8",
   "description": "",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
- Nominated withdraw transaction now calls API (however API is currently returning "missing raw transaction", so this has to be fixed by Anze)
- Adds support for multiple Modulr customer networks - MAINNET|TESTNET (previously it was dummy implementation, because it was not yet supported on BE)
- Better error message for transaction signing error