### PR TITLE
Release/2.0.0 beta.1

### DIFF
--- a/RNZumoKit.podspec
+++ b/RNZumoKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "RNZumoKit"
-  s.version      = "2.0.0-alpha.8"
+  s.version      = "2.0.0-beta.1"
   s.summary      = "RNZumoKit"
   s.description  = <<-DESC
                   RNZumoKit

--- a/android/src/main/java/com/zumokit/reactnative/RNZumoKitModule.java
+++ b/android/src/main/java/com/zumokit/reactnative/RNZumoKitModule.java
@@ -555,6 +555,7 @@ public class RNZumoKitModule extends ReactContextBaseJavaModule {
     String depositFee = composedExchangeMap.getString("depositFee");
     String exchangeFee = composedExchangeMap.getString("exchangeFee");
     String withdrawFee = composedExchangeMap.getString("withdrawFee");
+    String nonce = composedExchangeMap.getString("nonce");
 
     ComposedExchange composedExchange = new ComposedExchange(
             signedTransaction,
@@ -567,7 +568,8 @@ public class RNZumoKitModule extends ReactContextBaseJavaModule {
             returnValue,
             depositFee,
             exchangeFee,
-            withdrawFee
+            withdrawFee,
+            nonce
     );
 
     this.wallet.submitExchange(composedExchange, new SubmitExchangeCallback() {
@@ -1210,12 +1212,24 @@ public class RNZumoKitModule extends ReactContextBaseJavaModule {
     map.putMap("withdrawAccount", RNZumoKitModule.mapAccount(exchange.getWithdrawAccount()));
     map.putMap("exchangeRate", RNZumoKitModule.mapExchangeRate(exchange.getExchangeRate()));
     map.putMap("exchangeSettings", RNZumoKitModule.mapExchangeSettings(exchange.getExchangeSettings()));
-    map.putString("exchangeAddress", exchange.getExchangeAddress());
+
+    if (exchange.getExchangeAddress() == null) {
+      map.putNull("exchangeAddress");
+    } else {
+      map.putString("exchangeAddress", exchange.getExchangeAddress());
+    }
+
     map.putString("value", exchange.getValue());
     map.putString("returnValue", exchange.getReturnValue());
     map.putString("depositFee", exchange.getDepositFee());
     map.putString("exchangeFee", exchange.getExchangeFee());
     map.putString("withdrawFee", exchange.getWithdrawFee());
+
+    if (exchange.getNonce() == null) {
+      map.putNull("nonce");
+    } else {
+      map.putString("nonce", exchange.getNonce());
+    }
 
     return map;
   }
@@ -1251,6 +1265,13 @@ public class RNZumoKitModule extends ReactContextBaseJavaModule {
     map.putMap("exchangeRate",  RNZumoKitModule.mapExchangeRate(exchange.getExchangeRate()));
     map.putMap("exchangeRates",  RNZumoKitModule.mapExchangeRates(exchange.getExchangeRates()));
     map.putMap("exchangeSettings", RNZumoKitModule.mapExchangeSettings(exchange.getExchangeSettings()));
+
+    if (exchange.getNonce() == null) {
+      map.putNull("nonce");
+    } else {
+      map.putString("nonce", exchange.getNonce());
+    }
+
     map.putInt("submittedAt", exchange.getSubmittedAt().intValue());
 
     if(exchange.getConfirmedAt() == null) {

--- a/ios/RNZumoKit.m
+++ b/ios/RNZumoKit.m
@@ -492,8 +492,9 @@ RCT_EXPORT_METHOD(submitExchange:(NSDictionary *)composedExchangeData resolver:(
         NSString * depositFee = composedExchangeData[@"depositFee"];
         NSString * exchangeFee = composedExchangeData[@"exchangeFee"];
         NSString * withdrawFee = composedExchangeData[@"withdrawFee"];
+        NSString *nonce = (composedExchangeData[@"nonce"] == [NSNull null]) ? NULL : composedExchangeData[@"nonce"];
 
-        ZKComposedExchange * composedExchange = [[ZKComposedExchange alloc] initWithSignedTransaction:signedTransaction depositAccount:depositAccount withdrawAccount:withdrawAccount exchangeRate:exchangeRate exchangeSettings:exchangeSettings exchangeAddress:exchangeAddress value:value returnValue:returnValue depositFee:depositFee exchangeFee:exchangeFee withdrawFee:withdrawFee];
+        ZKComposedExchange * composedExchange = [[ZKComposedExchange alloc] initWithSignedTransaction:signedTransaction depositAccount:depositAccount withdrawAccount:withdrawAccount exchangeRate:exchangeRate exchangeSettings:exchangeSettings exchangeAddress:exchangeAddress value:value returnValue:returnValue depositFee:depositFee exchangeFee:exchangeFee withdrawFee:withdrawFee nonce:nonce];
 
        [_wallet submitExchange:composedExchange completion:^(ZKExchange * _Nullable exchange, NSError * _Nullable error) {
 
@@ -724,12 +725,13 @@ RCT_EXPORT_METHOD(clear:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseReje
          @"withdrawAccount": [self mapAccount:[exchange withdrawAccount]],
          @"exchangeRate": [self mapExchangeRate:[exchange exchangeRate]],
          @"exchangeSettings": [self mapExchangeSettings:[exchange exchangeSettings]],
-         @"exchangeAddress": [exchange exchangeAddress],
+         @"exchangeAddress": [exchange exchangeAddress] ? [exchange exchangeAddress] : [NSNull null],
          @"value": [exchange value],
          @"returnValue": [exchange returnValue],
          @"depositFee": [exchange depositFee],
          @"exchangeFee": [exchange exchangeFee],
          @"withdrawFee": [exchange withdrawFee],
+         @"nonce": [exchange nonce] ? [exchange nonce] : [NSNull null]
     };
 }
 
@@ -794,6 +796,7 @@ RCT_EXPORT_METHOD(clear:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseReje
          @"exchangeRate": [self mapExchangeRate:[exchange exchangeRate]],
          @"exchangeRates": [self mapExchangeRatesDict:[exchange exchangeRates]],
          @"exchangeSettings": [self mapExchangeSettings:[exchange exchangeSettings]],
+         @"nonce": [exchange nonce] ? [exchange nonce] : [NSNull null],
          @"submittedAt": [exchange submittedAt],
          @"confirmedAt": [exchange confirmedAt] ? [exchange confirmedAt] : [NSNull null],
     };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-zumo-kit",
-  "version": "2.0.0-alpha.8",
+  "version": "2.0.0-beta.1",
   "description": "",
   "main": "index.js",
   "scripts": {

--- a/src/models/ComposedExchange.js
+++ b/src/models/ComposedExchange.js
@@ -18,6 +18,7 @@ export default class ComposedExchange {
         this.returnAmount = new Decimal(json.returnValue);
         this.exchangeFee = new Decimal(json.exchangeFee);
         this.incomingTransactionFee = new Decimal(json.withdrawFee);
+        this.nonce = json.nonce;
     }
 
 }

--- a/src/models/Exchange.js
+++ b/src/models/Exchange.js
@@ -24,6 +24,7 @@ class Exchange {
         this.exchangeRate = new ExchangeRate(json.exchangeRate);
         this.exchangeSettings = new ExchangeSettings(json.exchangeSettings);
         this.exchangeRates = Parser.parseExchangeRates(json.exchangeRates);
+        this.nonce = json.nonce;
         this.submittedAt = json.submittedAt;
         this.confirmedAt = json.confirmedAt;
         this.timestamp = json.submittedAt;

--- a/src/models/User.js
+++ b/src/models/User.js
@@ -179,12 +179,16 @@ class User {
     * Get nominated account fiat properties
     *
     * @param {string} accountId
-    * @returns AccountFiatProperties
+    * @returns AccountFiatProperties | null
     * @memberof User
     */
     async getNominatedAccountFiatPoperties(accountId) {
-        const json = await RNZumoKit.getNominatedAccountFiatPoperties(accountId);
-        return new AccountFiatProperties(json);
+        try {
+            const json = await RNZumoKit.getNominatedAccountFiatPoperties(accountId);
+            return new AccountFiatProperties(json);
+        } catch (error) {
+            return null;
+        }
     }
 }
 


### PR DESCRIPTION
- Adds support for fiat exchanges
- Exchange and ComposedExchange now have nonce property
- exchangeAddress on ComposedExchange address is now optional property, ie. string or null
- FIX: Return null if no nominated account exists instead of rejecting promise

React Native wrapper is all yours now for two weeks. Have fun!