### PR TITLE
Add Build and Deploy Docs GitHub action

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,25 @@
+name: Build and Deploy Docs
+on:
+  create:
+    tags:
+      - "[0-9]+.[0-9]+.[0-9]+"
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2.3.1 # If you're using actions/checkout@v2 you must set persist-credentials to false in most cases for the deployment to work correctly.
+        with:
+          persist-credentials: false
+
+      - name: Install and Build # This example project is built using npm and outputs the result to the 'build' folder. Replace with the commands required to build your project, or remove this step entirely if your site is pre-built.
+        run: |
+          npm install
+          npm run docs
+
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@3.5.9
+        with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages # The branch the action should deploy to.
+          FOLDER: docs # The folder the action should deploy.

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "index.ts",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1",
-    "docs": "typedoc src/ --mode file --theme minimal --excludeExternals && open docs/index.html"
+    "docs": "typedoc src/ --mode file --theme minimal --excludeExternals"
   },
   "keywords": [
     "react-native"


### PR DESCRIPTION
Docs are automatically generated and pushed to gh-pages branch whenever a release tag [0-9]+.[0-9]+.[0-9]+ is created (this disqualifies alpha and beta releases).  gp-pages will be publicly available once I link it to GitHub Pages.