### PR TITLE
Expose all exchange rates, settings and rates. Add change listeners

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,5 @@
 
-built/
+lib/
 docs/
 
 # OSX

--- a/RNZumoKit.podspec
+++ b/RNZumoKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "RNZumoKit"
-  s.version      = "2.3.0-beta.2"
+  s.version      = "2.3.0-beta.3"
   s.summary      = "RNZumoKit"
   s.description  = <<-DESC
                   RNZumoKit

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,5 +40,5 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
     implementation 'com.android.support:appcompat-v7:21.0.0'
     implementation 'org.java-websocket:Java-WebSocket:1.4.0'
-    implementation 'com.github.zumo:zumokit-android:2.3.0-beta.2'
+    implementation 'com.github.zumo:zumokit-android:2.3.0-beta.3'
 }

--- a/android/src/main/java/com/zumokit/reactnative/RNZumoKitModule.java
+++ b/android/src/main/java/com/zumokit/reactnative/RNZumoKitModule.java
@@ -129,6 +129,7 @@ public class RNZumoKitModule extends ReactContextBaseJavaModule {
 
                 map.putString("id", user.getId());
                 map.putBoolean("hasWallet", user.hasWallet());
+                map.putArray("accounts", RNZumoKitModule.mapAccounts(user.getAccounts()));
 
                 promise.resolve(map);
             }

--- a/ios/RNZumoKit.m
+++ b/ios/RNZumoKit.m
@@ -1,9 +1,6 @@
 
 #import "RNZumoKit.h"
 #import <ZumoKit/ZumoKit.h>
-#import <ZumoKit/ZKAccountDataSnapshot.h>
-#import <ZumoKit/ZKZumoKitErrorCode.h>
-#import <ZumoKit/ZKZumoKitErrorType.h>
 
 @interface RNZumoKit ()
 
@@ -118,7 +115,8 @@ RCT_EXPORT_METHOD(signIn:(NSString *)tokenSet resolver:(RCTPromiseResolveBlock)r
 
             resolve(@{
                 @"id": [user getId],
-                @"hasWallet": @([user hasWallet])
+                @"hasWallet": @([user hasWallet]),
+                @"accounts": [self mapAccounts:[user getAccounts]]
             });
 
         }];

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-zumo-kit",
-  "version": "2.3.0-beta.2",
+  "version": "2.3.0-beta.3",
   "description": "ZumoKit is a Wallet as a Service SDK",
   "keywords": [
     "zumo",
@@ -15,13 +15,8 @@
     "bsv",
     "erc20 tokens"
   ],
-  "main": "lib/ZumoKit.js",
-  "types": "lib/ZumoKit.d.ts",
-  "files": ["lib", "RNZumoKit.podspec"],
+  "main": "src/ZumoKit.ts",
   "scripts": {
-    "build": "tsc",
-    "prepare": "npm run build",
-    "prepack": "npm run build",
     "test": "echo \"Error: no test specified\" && exit 1",
     "docs": "typedoc"
   },

--- a/package.json
+++ b/package.json
@@ -1,17 +1,37 @@
 {
   "name": "react-native-zumo-kit",
   "version": "2.3.0-beta.2",
-  "description": "",
-  "main": "src/ZumoKit.ts",
+  "description": "ZumoKit is a Wallet as a Service SDK",
+  "keywords": [
+    "zumo",
+    "zumokit",
+    "react native",
+    "blockchain",
+    "wallet",
+    "payments",
+    "cryptocurrency",
+    "ethereum",
+    "bitcoin",
+    "bsv",
+    "erc20 tokens"
+  ],
+  "main": "lib/ZumoKit.js",
+  "types": "lib/ZumoKit.d.ts",
+  "files": ["lib", "RNZumoKit.podspec"],
   "scripts": {
+    "build": "tsc",
+    "prepare": "npm run build",
+    "prepack": "npm run build",
     "test": "echo \"Error: no test specified\" && exit 1",
     "docs": "typedoc"
   },
-  "keywords": [
-    "react-native"
-  ],
-  "author": "",
-  "license": "",
+  "author": "Zumo (https://www.zumo.money)",
+  "homepage": "https://www.zumo.money/developers",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/zumo/zumokit-react-native"
+  },
   "peerDependencies": {
     "react-native": "^0.62.14"
   },

--- a/src/Wallet.ts
+++ b/src/Wallet.ts
@@ -6,7 +6,7 @@ import Exchange from './models/Exchange';
 import ComposedExchange from './models/ComposedExchange';
 import tryCatchProxy from './errorProxy';
 import ExchangeRate from './models/ExchangeRate';
-import ExchangeSettings from './models/ExchangeSettings';
+import ExchangeSetting from './models/ExchangeSetting';
 
 const { RNZumoKit } = NativeModules;
 
@@ -151,7 +151,7 @@ export default class Wallet {
    * @param fromAccountId       {@link  Account Account} identifier
    * @param toAccountId         {@link  Account Account} identifier
    * @param exchangeRate        Zumo exchange rate obtained from ZumoKit state
-   * @param exchangeSettings    Zumo exchange settings obtained from ZumoKit state
+   * @param exchangeSetting     Zumo exchange setting obtained from ZumoKit state
    * @param amount              amount in deposit account currency
    * @param sendMax             exchange maximum possible funds
    */
@@ -159,7 +159,7 @@ export default class Wallet {
     fromAccountId: string,
     toAccountId: string,
     exchangeRate: ExchangeRate,
-    exchangeSettings: ExchangeSettings,
+    exchangeSetting: ExchangeSetting,
     amount: Decimal | null,
     sendMax = false
   ) {
@@ -167,7 +167,7 @@ export default class Wallet {
       fromAccountId,
       toAccountId,
       exchangeRate.json,
-      exchangeSettings.json,
+      exchangeSetting.json,
       amount ? amount.toString() : null,
       sendMax
     );

--- a/src/ZumoKit.ts
+++ b/src/ZumoKit.ts
@@ -2,12 +2,12 @@ import { NativeModules } from 'react-native';
 import Utils from './Utils';
 import User from './User';
 import tryCatchProxy from './errorProxy';
-import FeeRates from './models/FeeRates';
+import TransactionFeeRate from './models/TransactionFeeRate';
 import ExchangeRate from './models/ExchangeRate';
-import ExchangeSettings from './models/ExchangeSettings';
+import ExchangeSetting from './models/ExchangeSetting';
 import HistoricalExchangeRates from './models/HistoricalExchangeRates';
 import { parseHistoricalExchangeRates } from './utils/parse';
-import { CurrencyCode, TokenSet, HistoricalExchangeRatesJSON } from './types';
+import { Dictionary, CurrencyCode, TokenSet, HistoricalExchangeRatesJSON } from './types';
 
 const { RNZumoKit } = NativeModules;
 
@@ -26,6 +26,15 @@ class ZumoKit {
 
   /** Crypto utilities. */
   utils: Utils = new Utils();
+
+  /** Mapping between currency pairs and available exchange rates. */
+  exchangeRates: Dictionary<CurrencyCode, Dictionary<CurrencyCode, ExchangeRate>> = {};
+
+  /** Mapping between currency pairs and available exchange settings. */
+  exchangeSettings: Dictionary<CurrencyCode, Dictionary<CurrencyCode, ExchangeSetting>> = {};
+
+  /** Mapping between cryptocurrencies and available transaction fee rates. */
+  transactionFeeRates: Dictionary<CurrencyCode, TransactionFeeRate> = {};
 
   /**
    * Initializes ZumoKit SDK. Should only be called once.
@@ -83,7 +92,7 @@ class ZumoKit {
    */
   async getExchangeSettings(fromCurrency: CurrencyCode, toCurrency: CurrencyCode) {
     const json = await RNZumoKit.getExchangeSettings(fromCurrency, toCurrency);
-    return json ? new ExchangeSettings(json) : null;
+    return json ? new ExchangeSetting(json) : null;
   }
 
   /**
@@ -95,7 +104,7 @@ class ZumoKit {
    */
   async getFeeRates(currency: CurrencyCode) {
     const json = await RNZumoKit.getFeeRates(currency);
-    return json ? new FeeRates(json) : null;
+    return json ? new TransactionFeeRate(json) : null;
   }
 
   /**

--- a/src/models/ComposedExchange.ts
+++ b/src/models/ComposedExchange.ts
@@ -1,7 +1,7 @@
 import { Decimal } from 'decimal.js';
 import Account from './Account';
 import ExchangeRate from './ExchangeRate';
-import ExchangeSettings from './ExchangeSettings';
+import ExchangeSetting from './ExchangeSetting';
 import { ComposedExchangeJSON } from '../types';
 
 /** Result of the compose exchange method on {@link  Wallet Wallet} object. */
@@ -22,7 +22,7 @@ export default class ComposedExchange {
   exchangeRate: ExchangeRate;
 
   /** Exchange settings used composing exchange. */
-  exchangeSettings: ExchangeSettings;
+  exchangeSetting: ExchangeSetting;
 
   /**
    * Zumo Exchange Service wallet address where outgoing crypto funds were deposited,
@@ -39,21 +39,21 @@ export default class ComposedExchange {
   /**
    * Amount that user receives, calculated as <code>value X exchangeRate X (1 - feeRate) - returnTransactionFee</code>.
    * <p>
-   * See {@link ExchangeSettings}.
+   * See {@link ExchangeSetting}.
    */
   returnAmount: Decimal;
 
   /**
    * Exchange fee, calculated as <code>value X exchangeRate X exchangeFeeRate</code>.
    * <p>
-   * See {@link ExchangeSettings}.
+   * See {@link ExchangeSetting}.
    */
   exchangeFee: Decimal;
 
   /**
    * Return transaction fee.
    * <p>
-   * See {@link ExchangeSettings}.
+   * See {@link ExchangeSetting}.
    */
   returnTransactionFee: Decimal;
 
@@ -67,7 +67,7 @@ export default class ComposedExchange {
     this.fromAccount = new Account(json.fromAccount);
     this.toAccount = new Account(json.toAccount);
     this.exchangeRate = new ExchangeRate(json.exchangeRate);
-    this.exchangeSettings = new ExchangeSettings(json.exchangeSettings);
+    this.exchangeSetting = new ExchangeSetting(json.exchangeSetting);
     this.exchangeAddress = json.exchangeAddress;
     this.amount = new Decimal(json.amount);
     this.outgoingTransactionFee = new Decimal(json.outgoingTransactionFee);

--- a/src/models/Exchange.ts
+++ b/src/models/Exchange.ts
@@ -1,6 +1,6 @@
 import { Decimal } from 'decimal.js';
 import ExchangeRate from './ExchangeRate';
-import ExchangeSettings from './ExchangeSettings';
+import ExchangeSetting from './ExchangeSetting';
 import { Dictionary, ExchangeStatus, CurrencyCode, ExchangeJSON } from '../types';
 import { parseExchangeRates } from '../utils/parse';
 
@@ -45,22 +45,22 @@ export default class Exchange {
   /**
    * Amount that user receives in target account currency, calculated as <code>amount X exchangeRate X (1 - feeRate) - returnTransactionFee</code>.
    * <p>
-   * See {@link ExchangeSettings}.
+   * See {@link ExchangeSetting}.
    */
   returnAmount: Decimal;
 
   /**
    * Exchange fee in target account currency, calculated as <code>amount X exchangeRate X exchangeFeeRate</code>.
    * <p>
-   * See {@link ExchangeSettings}.
+   * See {@link ExchangeSetting}.
    */
   exchangeFee: Decimal;
 
   /** Exchange rate used. */
   exchangeRate: ExchangeRate;
 
-  /** Exchange settings used. */
-  exchangeSettings: ExchangeSettings;
+  /** Exchange setting used. */
+  exchangeSetting: ExchangeSetting;
 
   /**
    * Exchange rates at the time exchange was made.
@@ -99,7 +99,7 @@ export default class Exchange {
     this.returnAmount = new Decimal(json.returnAmount);
     this.exchangeFee = new Decimal(json.exchangeFee);
     this.exchangeRate = new ExchangeRate(json.exchangeRate);
-    this.exchangeSettings = new ExchangeSettings(json.exchangeSettings);
+    this.exchangeSetting = new ExchangeSetting(json.exchangeSetting);
     this.exchangeRates = parseExchangeRates(json.exchangeRates);
     this.nonce = json.nonce;
     this.submittedAt = json.submittedAt;

--- a/src/models/ExchangeSetting.ts
+++ b/src/models/ExchangeSetting.ts
@@ -1,6 +1,14 @@
 import { Decimal } from 'decimal.js';
 import { Dictionary, Network, CurrencyCode, ExchangeSettingJSON } from '../types';
-import { parseExchangeAddressMap } from '../utils/parse';
+
+/** @internal */
+const parseExchangeAddressMap = (exchangeAddressMapJSON: Record<string, string>) => {
+  const exchangeAddressMap: Dictionary<Network, string> = {};
+  Object.keys(exchangeAddressMapJSON).forEach((network) => {
+    exchangeAddressMap[network as Network] = exchangeAddressMapJSON[network];
+  });
+  return exchangeAddressMap;
+};
 
 /** Zumo exchange settings used in making exchanges. */
 export default class ExchangeSetting {

--- a/src/models/ExchangeSetting.ts
+++ b/src/models/ExchangeSetting.ts
@@ -1,11 +1,11 @@
 import { Decimal } from 'decimal.js';
-import { Dictionary, Network, CurrencyCode, ExchangeSettingsJSON } from '../types';
+import { Dictionary, Network, CurrencyCode, ExchangeSettingJSON } from '../types';
 import { parseExchangeAddressMap } from '../utils/parse';
 
 /** Zumo exchange settings used in making exchanges. */
-export default class ExchangeSettings {
+export default class ExchangeSetting {
   /** @internal */
-  json: ExchangeSettingsJSON;
+  json: ExchangeSettingJSON;
 
   /** Identifier. */
   id: string;
@@ -39,7 +39,7 @@ export default class ExchangeSettings {
   timestamp: number;
 
   /** @internal */
-  constructor(json: ExchangeSettingsJSON) {
+  constructor(json: ExchangeSettingJSON) {
     this.json = json;
     this.id = json.id;
     this.fromCurrency = json.fromCurrency as CurrencyCode;

--- a/src/models/HistoricalExchangeRates.ts
+++ b/src/models/HistoricalExchangeRates.ts
@@ -1,16 +1,9 @@
 import ExchangeRate from './ExchangeRate';
-import {
-  CurrencyCode,
-  Dictionary,
-  TimeInterval,
-} from '../types';
+import { CurrencyCode, Dictionary, TimeInterval } from '../types';
 
 type HistoricalExchangeRates = Dictionary<
   TimeInterval,
-  Dictionary<
-    CurrencyCode,
-    Dictionary<CurrencyCode, Array<ExchangeRate>>
-  >
+  Dictionary<CurrencyCode, Dictionary<CurrencyCode, Array<ExchangeRate>>>
 >;
 
 export default HistoricalExchangeRates;

--- a/src/models/TransactionCryptoProperties.ts
+++ b/src/models/TransactionCryptoProperties.ts
@@ -1,6 +1,14 @@
 import { Decimal } from 'decimal.js';
 import { TransactionCryptoPropertiesJSON, Dictionary, CurrencyCode } from '../types';
-import { parseFiatMap } from '../utils/parse';
+
+/** @internal */
+const parseFiatMap = (fiatMapJSON: Record<string, string>) => {
+  const fiatMap: Dictionary<CurrencyCode, Decimal> = {};
+  Object.keys(fiatMapJSON).forEach((currencyCode) => {
+    fiatMap[currencyCode as CurrencyCode] = new Decimal(fiatMapJSON[currencyCode]);
+  });
+  return fiatMap;
+};
 
 /**
  * Record containing transaction crypto properties.

--- a/src/models/TransactionFeeRate.ts
+++ b/src/models/TransactionFeeRate.ts
@@ -1,10 +1,10 @@
 import { Decimal } from 'decimal.js';
-import { FeeRatesJSON } from '../types';
+import { TransactionFeeRateJSON } from '../types';
 
 /** Crypto transactions fee rates. */
 export default class FeeRates {
   /** @internal */
-  json: FeeRatesJSON;
+  json: TransactionFeeRateJSON;
 
   /** Fee rate resulting in slow confirmation time. */
   slow: Decimal;
@@ -28,7 +28,7 @@ export default class FeeRates {
   source: string;
 
   /** @internal */
-  constructor(json: FeeRatesJSON) {
+  constructor(json: TransactionFeeRateJSON) {
     this.json = json;
     this.slow = new Decimal(json.slow);
     this.average = new Decimal(json.average);

--- a/src/models/TransactionFeeRate.ts
+++ b/src/models/TransactionFeeRate.ts
@@ -2,7 +2,7 @@ import { Decimal } from 'decimal.js';
 import { TransactionFeeRateJSON } from '../types';
 
 /** Crypto transactions fee rates. */
-export default class FeeRates {
+export default class TransactionFeeRate {
   /** @internal */
   json: TransactionFeeRateJSON;
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -93,7 +93,7 @@ export interface ExchangeRateJSON {
 }
 
 /** @internal */
-export interface ExchangeSettingsJSON {
+export interface ExchangeSettingJSON {
   id: string;
   fromCurrency: string;
   toCurrency: string;
@@ -123,7 +123,7 @@ export interface ComposedExchangeJSON {
   fromAccount: AccountJSON;
   toAccount: AccountJSON;
   exchangeRate: ExchangeRateJSON;
-  exchangeSettings: ExchangeSettingsJSON;
+  exchangeSetting: ExchangeSettingJSON;
   exchangeAddress: string | null;
   amount: string;
   outgoingTransactionFee: string;
@@ -134,7 +134,7 @@ export interface ComposedExchangeJSON {
 }
 
 /** @internal */
-export interface FeeRatesJSON {
+export interface TransactionFeeRateJSON {
   slow: string;
   average: string;
   fast: string;
@@ -201,7 +201,7 @@ export interface ExchangeJSON {
   returnAmount: string;
   exchangeFee: string;
   exchangeRate: ExchangeRateJSON;
-  exchangeSettings: ExchangeSettingsJSON;
+  exchangeSetting: ExchangeSettingJSON;
   exchangeRates: Record<string, Record<string, ExchangeRateJSON>>;
   nonce: string | null;
   submittedAt: number;
@@ -213,6 +213,7 @@ export interface ExchangeJSON {
 export interface UserJSON {
   id: string;
   hasWallet: boolean;
+  accounts: Array<AccountJSON>;
 }
 
 /** @internal */

--- a/src/utils/parse.ts
+++ b/src/utils/parse.ts
@@ -1,24 +1,14 @@
-import Decimal from 'decimal.js';
 import ExchangeRate from '../models/ExchangeRate';
-import { ExchangeRateJSON, CurrencyCode, Dictionary, TimeInterval, Network } from '../types';
-
-/** @internal */
-const parseFiatMap = (fiatMapJSON: Record<string, string>) => {
-  const fiatMap: Dictionary<CurrencyCode, Decimal> = {};
-  Object.keys(fiatMapJSON).forEach((currencyCode) => {
-    fiatMap[currencyCode as CurrencyCode] = new Decimal(fiatMapJSON[currencyCode]);
-  });
-  return fiatMap;
-};
-
-/** @internal */
-const parseExchangeAddressMap = (exchangeAddressMapJSON: Record<string, string>) => {
-  const exchangeAddressMap: Dictionary<Network, string> = {};
-  Object.keys(exchangeAddressMapJSON).forEach((network) => {
-    exchangeAddressMap[network as Network] = exchangeAddressMapJSON[network];
-  });
-  return exchangeAddressMap;
-};
+import ExchangeSetting from '../models/ExchangeSetting';
+import TransactionFeeRate from '../models/TransactionFeeRate';
+import {
+  ExchangeRateJSON,
+  ExchangeSettingJSON,
+  TransactionFeeRateJSON,
+  CurrencyCode,
+  Dictionary,
+  TimeInterval,
+} from '../types';
 
 /** @internal */
 const parseExchangeRates = (
@@ -35,6 +25,36 @@ const parseExchangeRates = (
     exchangeRatesMap[depositCurrency as CurrencyCode] = innerMap;
   });
   return exchangeRatesMap;
+};
+
+/** @internal */
+const parseExchangeSettings = (
+  exchangeSettingsMapJSON: Record<string, Record<string, ExchangeSettingJSON>>
+) => {
+  const exchangeSettings: Dictionary<CurrencyCode, Dictionary<CurrencyCode, ExchangeSetting>> = {};
+  Object.keys(exchangeSettingsMapJSON).forEach((depositCurrency) => {
+    const innerMap: Dictionary<CurrencyCode, ExchangeSetting> = {};
+    Object.keys(exchangeSettingsMapJSON[depositCurrency]).forEach((withdrawCurrency) => {
+      innerMap[withdrawCurrency as CurrencyCode] = new ExchangeSetting(
+        exchangeSettingsMapJSON[depositCurrency][withdrawCurrency]
+      );
+    });
+    exchangeSettings[depositCurrency as CurrencyCode] = innerMap;
+  });
+  return exchangeSettings;
+};
+
+/** @internal */
+const parseTransactionFeeRates = (
+  transactionFeeRatesJSON: Record<string, TransactionFeeRateJSON>
+) => {
+  const feeRates: Dictionary<CurrencyCode, TransactionFeeRate> = {};
+  Object.keys(transactionFeeRatesJSON).forEach((currencyCode) => {
+    feeRates[currencyCode as CurrencyCode] = new TransactionFeeRate(
+      transactionFeeRatesJSON[currencyCode]
+    );
+  });
+  return feeRates;
 };
 
 /** @internal */
@@ -72,4 +92,9 @@ const parseHistoricalExchangeRates = (
   return exchangeRateMap;
 };
 
-export { parseFiatMap, parseExchangeAddressMap, parseExchangeRates, parseHistoricalExchangeRates };
+export {
+  parseExchangeRates,
+  parseExchangeSettings,
+  parseTransactionFeeRates,
+  parseHistoricalExchangeRates,
+};

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,10 +7,11 @@
       "es2017",
       "es6"
     ],
-    "outDir": "./built",
+    "outDir": "lib",
     "allowJs": false,
     "target": "es5",
     "noEmitOnError": true,
     "noImplicitAny": true,
+    "declaration": true
   }
 }


### PR DESCRIPTION
- Renamed exchangeSettings to exchangeSetting
- Renamed feeRates to transactionFeeRate
- zumokit instance:
  - Added exchangeRates, exchangeSettings and transactionFeeRates properties
  - These properties are **populated once user is signed in**
  - getExchangeRate, getExchangeSetting and getTransactionFeeRates methods are **not** async anymore
  - Added addChangeListener/removeChangeListener methods to listen to exchange rates, exchange settings and transaction fees changed
- user instance:
  - Replaced getAccounts, getId and hasWallet methods with properties accounts, id and hasWallet on user instance
  - getAccount method is **not** async anymore