### PR TITLE
Attempt to solve 'Error when sending event'

### DIFF
--- a/ios/RNZumoKit.m
+++ b/ios/RNZumoKit.m
@@ -14,12 +14,24 @@
 
 @implementation RNZumoKit
 
+RCT_EXPORT_MODULE()
+
+bool hasListeners;
+
+static id _instance;
+
++ (instancetype)allocWithZone:(struct _NSZone *)zone {
+    static dispatch_once_t onceToken;
+    dispatch_once(&onceToken, ^{
+        _instance = [super allocWithZone:zone];
+    });
+    return _instance;
+}
+
 -  (NSDictionary *)decimalLocale
 {
     return [NSDictionary dictionaryWithObject:@"." forKey:NSLocaleDecimalSeparator];
 }
-
-bool hasListeners;
 
 // Let's run the methods in a separate queue!
 - (dispatch_queue_t)methodQueue
@@ -65,9 +77,6 @@ bool hasListeners;
                 errorCode:ZKZumoKitErrorCodeUNKNOWNERROR
                 errorMessage:errorMessage];
 }
-
-
-RCT_EXPORT_MODULE()
 
 # pragma mark - Events
 


### PR DESCRIPTION
According to https://www.programmersought.com/article/4256611911/ forcing class allocator to make a singleton should resolve the issue of missing bridge. It is similar to the idea mentioned here - https://github.com/facebook/react-native/issues/15421.

If the crash keeps appearing I will just add the following hack:
```objc
if (self.bridge) {   
  [self sendEventWithName:@"AccountDataChanged" body:[self mapAccountData:snapshots]];
}
```

That is the way they do it on Discovery channel - https://github.com/invertase/react-native-firebase/commit/e76ab93a7285a899deb066bf854c040260d83be1