### PR TITLE
Bump version. Run iOS methods on money.zumo.zumokit queue

### DIFF
--- a/RNZumoKit.podspec
+++ b/RNZumoKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "RNZumoKit"
-  s.version      = "2.2.3"
+  s.version      = "2.2.4"
   s.summary      = "RNZumoKit"
   s.description  = <<-DESC
                   RNZumoKit

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,5 +40,5 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
     implementation 'com.android.support:appcompat-v7:21.0.0'
     implementation 'org.java-websocket:Java-WebSocket:1.4.0'
-    implementation 'com.github.zumo:zumokit-android:2.2.3'
+    implementation 'com.github.zumo:zumokit-android:2.2.4'
 }

--- a/ios/RNZumoKit.m
+++ b/ios/RNZumoKit.m
@@ -33,11 +33,9 @@ static id _instance;
     return [NSDictionary dictionaryWithObject:@"." forKey:NSLocaleDecimalSeparator];
 }
 
-// ZumoKit iOS SDK runs its WebSockets on the main queue. Running other methods 
-// in a separate queue introduces mememory access race conditions and crashes.
 - (dispatch_queue_t)methodQueue
 {
-    return dispatch_get_main_queue();
+    return dispatch_queue_create("money.zumo.zumokit", DISPATCH_QUEUE_SERIAL);
 }
 
 - (NSDictionary *)constantsToExport

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "react-native": "^0.62.14"
   },
   "dependencies": {
-    "zumokit": "2.2.3",
+    "zumokit": "2.2.4",
     "decimal.js": "^10.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
I have changed the iOS queue again. So we can see if the crash has been resolved on iOS too.

You can use this commit hash to test it - 81673a031fd30b9e44fdbeda36e9d562bf2744c8