### PR TITLE
Bump version. Set minimum iOS deployment target to 11.0

### DIFF
--- a/RNZumoKit.podspec
+++ b/RNZumoKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "RNZumoKit"
-  s.version      = "2.3.0-beta.10"
+  s.version      = "2.3.0-beta.11"
   s.summary      = "RNZumoKit"
   s.description  = <<-DESC
                   RNZumoKit
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.license      = "MIT"
   s.author       = { "author" => "Zumo" }
   s.platform     = :ios
-  s.ios.deployment_target = "10.0"
+  s.ios.deployment_target = "11.0"
   s.source       = { :git => "https://github.com/zumo/zumokit-react-native.git", :tag => "#{s.version}" }
   s.source_files  = "ios/**/*.{h,m,mm}"
   s.requires_arc = true

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,5 +40,5 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
     implementation 'com.android.support:appcompat-v7:21.0.0'
     implementation 'org.java-websocket:Java-WebSocket:1.4.0'
-    implementation 'com.github.zumo:zumokit-android:2.3.0-beta.10'
+    implementation 'com.github.zumo:zumokit-android:2.3.0-beta.11'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-zumo-kit",
-  "version": "2.3.0-beta.10",
+  "version": "2.3.0-beta.11",
   "description": "ZumoKit is a Wallet as a Service SDK",
   "keywords": [
     "zumo",
@@ -31,7 +31,7 @@
     "react-native": "^0.62.14"
   },
   "dependencies": {
-    "zumokit": "2.3.0-beta.10",
+    "zumokit": "2.3.0-beta.11",
     "decimal.js": "^10.2.0"
   },
   "devDependencies": {


### PR DESCRIPTION
- Remove 32 bit iOS binaries and set minimum deployment target to iOS 11.0.
- Set error message when user tries to use exchange max with insufficient funds to “You don’t have enough funds to make a minimum exchange”.
- Fix key "returnTransaction" not found bug when submitting exchange.