### PR TITLE
Release/2.3.0 beta.13

### DIFF
--- a/RNZumoKit.podspec
+++ b/RNZumoKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "RNZumoKit"
-  s.version      = "2.3.0-beta.12"
+  s.version      = "2.3.0-beta.13"
   s.summary      = "RNZumoKit"
   s.description  = <<-DESC
                   RNZumoKit
@@ -11,7 +11,7 @@ Pod::Spec.new do |s|
   s.license      = "MIT"
   s.author       = { "author" => "Zumo" }
   s.platform     = :ios
-  s.ios.deployment_target = "11.0"
+  s.ios.deployment_target = "12.0"
   s.source       = { :git => "https://github.com/zumo/zumokit-react-native.git", :tag => "#{s.version}" }
   s.source_files  = "ios/**/*.{h,m,mm}"
   s.requires_arc = true

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,5 +40,5 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
     implementation 'com.android.support:appcompat-v7:21.0.0'
     implementation 'org.java-websocket:Java-WebSocket:1.4.0'
-    implementation 'com.github.zumo:zumokit-android:2.3.0-beta.12'
+    implementation 'com.github.zumo:zumokit-android:2.3.0-beta.13'
 }

--- a/android/src/main/java/com/zumokit/reactnative/RNZumoKitModule.java
+++ b/android/src/main/java/com/zumokit/reactnative/RNZumoKitModule.java
@@ -13,6 +13,7 @@ import com.facebook.react.bridge.ReadableMapKeySetIterator;
 
 import com.facebook.react.modules.core.DeviceEventManagerModule;
 
+import money.zumo.zumokit.LogListener;
 import money.zumo.zumokit.AccountDataSnapshot;
 import money.zumo.zumokit.AccountFiatPropertiesCallback;
 import money.zumo.zumokit.Address;
@@ -100,6 +101,27 @@ public class RNZumoKitModule extends ReactContextBaseJavaModule {
                 ZumoKitErrorType.INVALID_REQUEST_ERROR,
                 ZumoKitErrorCode.UNKNOWN_ERROR,
                 errorMessage
+        );
+    }
+
+    @ReactMethod
+    public void setLogLevel(String logLevel) {
+        ZumoKit.setLogLevel(logLevel);
+    }
+
+    @ReactMethod
+    public void addLogListener(String logLevel) {
+        RNZumoKitModule module = this;
+        ZumoKit.onLog(
+                new LogListener() {
+                    @Override
+                    public void onLog(String message) {
+                        module.reactContext
+                                .getJSModule(DeviceEventManagerModule.RCTDeviceEventEmitter.class)
+                                .emit("OnLog", message);
+                    }
+                },
+                logLevel
         );
     }
 

--- a/ios/RNZumoKit.m
+++ b/ios/RNZumoKit.m
@@ -81,7 +81,7 @@ static id _instance;
 
 - (NSArray<NSString *> *)supportedEvents
 {
-    return @[@"AuxDataChanged", @"AccountDataChanged"];
+    return @[@"OnLog", @"AuxDataChanged", @"AccountDataChanged"];
 }
 
 - (void)startObserving
@@ -92,6 +92,11 @@ static id _instance;
 - (void)stopObserving
 {
     hasListeners = NO;
+}
+
+- (void)onLog:(nonnull NSString *)message
+{
+    [self sendEventWithName:@"OnLog" body:message];
 }
 
 
@@ -109,6 +114,18 @@ static id _instance;
     [self sendEventWithName:@"AccountDataChanged" body:[self mapAccountData:snapshots]];
 }
 
+# pragma mark - Logging
+
+RCT_EXPORT_METHOD(setLogLevel:(NSString *)logLevel)
+{
+    
+    [ZumoKit setLogLevel:logLevel];
+}
+
+RCT_EXPORT_METHOD(addLogListener:(NSString *)logLevel)
+{
+    [ZumoKit onLog:self logLevel:logLevel];
+}
 
 # pragma mark - Initialization + Authentication
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-zumo-kit",
-  "version": "2.3.0-beta.12",
+  "version": "2.3.0-beta.13",
   "description": "ZumoKit is a Wallet as a Service SDK",
   "keywords": [
     "zumo",
@@ -31,7 +31,7 @@
     "react-native": "^0.62.14"
   },
   "dependencies": {
-    "zumokit": "2.3.0-beta.12",
+    "zumokit": "2.3.0-beta.13",
     "decimal.js": "^10.2.0"
   },
   "devDependencies": {

--- a/src/ZumoKit.ts
+++ b/src/ZumoKit.ts
@@ -9,6 +9,7 @@ import {
   HistoricalExchangeRates,
 } from 'zumokit/src/models';
 import {
+  LogLevel,
   CurrencyCode,
   TokenSet,
   HistoricalExchangeRatesJSON,
@@ -54,6 +55,29 @@ class ZumoKit {
 
   /** Mapping between cryptocurrencies and available transaction fee rates. */
   transactionFeeRates: TransactionFeeRates = {};
+
+  /**
+   * Sets log level for current logger.
+   *
+   * @param logLevel log level, e.g. 'debug' or 'info'
+   */
+  setLogLevel(logLevel: LogLevel) {
+    RNZumoKit.setLogLevel(logLevel);
+  }
+
+  /**
+   * Sets log handler for all ZumoKit related logs.
+   *
+   * @param listener interface to listen to changes
+   * @param logLevel log level, e.g. 'debug' or 'info'
+   */
+  onLog(listener: (message: string) => void, logLevel: LogLevel) {
+    this.emitter.addListener('OnLog', (message: string) => {
+      listener(message);
+    });
+
+    RNZumoKit.addLogListener(logLevel);
+  }
 
   /**
    * Initializes ZumoKit SDK. Should only be called once.


### PR DESCRIPTION
Usage is extremely simple - just add log listener before initializing ZumoKit, e.g.
```
zumokit.onLog(console.log, 'debug');
```

Side note - iOS build will be complaining about const string DEBUG, since apparently DEBUG is reserved keyword, just delete the entire line in case of build issues. I will push an update but it will take some time to rebuild SDK.