### PR TITLE
Release/3.0.0-beta.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,7 +72,13 @@ Entry point to ZumoKit SDK is `loadZumoKit` function. This function returns a Pr
 ```typescript
 import zumokit from 'react-native-zumo-kit';
 
-zumokit.init(API_KEY, API_URL, TRANSACTION_SERVICE_URL, CARD_SERVICE_URL);
+zumokit.init(
+  API_KEY, 
+  API_URL, 
+  TRANSACTION_SERVICE_URL, 
+  CARD_SERVICE_URL,
+  NOTIFICATION_SERVICE_URL
+);
 ```
 
 Ask your [account manager](mailto:support@zumo.money) to provide you with necessary credentials.

--- a/RNZumoKit.podspec
+++ b/RNZumoKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "RNZumoKit"
-  s.version      = "3.0.0-beta.1"
+  s.version      = "3.0.0-beta.2"
   s.summary      = "RNZumoKit"
   s.description  = <<-DESC
                   RNZumoKit

--- a/RNZumoKit.podspec
+++ b/RNZumoKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "RNZumoKit"
-  s.version      = "2.4.1"
+  s.version      = "3.0.0-beta.1"
   s.summary      = "RNZumoKit"
   s.description  = <<-DESC
                   RNZumoKit

--- a/android/.project
+++ b/android/.project
@@ -14,4 +14,15 @@
 	<natures>
 		<nature>org.eclipse.buildship.core.gradleprojectnature</nature>
 	</natures>
+	<filteredResources>
+		<filter>
+			<id>1620390164575</id>
+			<name></name>
+			<type>30</type>
+			<matcher>
+				<id>org.eclipse.core.resources.regexFilterMatcher</id>
+				<arguments>node_modules|.git|__CREATED_BY_JAVA_LANGUAGE_SERVER__</arguments>
+			</matcher>
+		</filter>
+	</filteredResources>
 </projectDescription>

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -1,23 +1,24 @@
 
 buildscript {
     repositories {
-        jcenter()
+        google()
+        mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.3.1'
+        classpath 'com.android.tools.build:gradle:4.2.0'
     }
 }
 
 apply plugin: 'com.android.library'
 
 android {
-    compileSdkVersion 23
+    compileSdkVersion 30
     buildToolsVersion "28.0.3"
 
     defaultConfig {
         minSdkVersion 21
-        targetSdkVersion 21
+        targetSdkVersion 30
         versionCode 1
         versionName "1.0"
     }
@@ -31,6 +32,7 @@ android {
 }
 
 repositories {
+    google()
     mavenCentral()
     maven { url 'https://jitpack.io' }
 }
@@ -38,7 +40,7 @@ repositories {
 dependencies {
     implementation 'com.facebook.react:react-native:+'
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
-    implementation 'com.android.support:appcompat-v7:21.0.0'
+    implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'org.java-websocket:Java-WebSocket:1.4.0'
-    implementation 'com.github.zumo:zumokit-android:2.4.1'
+    implementation 'com.github.zumo:zumokit-android:3.0.0-beta.1'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,5 +42,5 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'org.java-websocket:Java-WebSocket:1.4.0'
-    implementation 'com.github.zumo:zumokit-android:3.0.0-beta.1'
+    implementation 'com.github.zumo:zumokit-android:3.0.0-beta.2'
 }

--- a/android/src/main/java/com/zumokit/reactnative/RNZumoKitModule.java
+++ b/android/src/main/java/com/zumokit/reactnative/RNZumoKitModule.java
@@ -126,8 +126,18 @@ public class RNZumoKitModule extends ReactContextBaseJavaModule {
     }
 
     @ReactMethod
-    public void init(String apiKey, String apiUrl, String transactionServiceUrl, String cardServiceUrl) {
-        this.zumokit = new ZumoKit(apiKey, apiUrl, transactionServiceUrl, cardServiceUrl);
+    public void init(
+        String apiKey, 
+        String apiUrl, 
+        String transactionServiceUrl, 
+        String cardServiceUrl,
+        String notificationServiceUrl) {
+        this.zumokit = new ZumoKit(
+            apiKey, 
+            apiUrl, 
+            transactionServiceUrl, 
+            cardServiceUrl,
+            notificationServiceUrl);
 
         RNZumoKitModule module = this;
         this.zumokit.addChangeListener(new ChangeListener() {

--- a/ios/RNZumoKit.m
+++ b/ios/RNZumoKit.m
@@ -129,9 +129,9 @@ RCT_EXPORT_METHOD(addLogListener:(NSString *)logLevel)
 
 # pragma mark - Initialization + Authentication
 
-RCT_EXPORT_METHOD(init:(NSString *)apiKey apiUrl:(NSString *)apiUrl transactionServiceUrl:(NSString *)transactionServiceUrl cardServiceUrl:(NSString *)cardServiceUrl)
+RCT_EXPORT_METHOD(init:(NSString *)apiKey apiUrl:(NSString *)apiUrl transactionServiceUrl:(NSString *)transactionServiceUrl cardServiceUrl:(NSString *)cardServiceUrl notificationServiceUrl:(NSString *)notificationServiceUrl)
 {
-    _zumoKit = [[ZumoKit alloc] initWithApiKey:apiKey apiUrl:apiUrl transactionServiceUrl:transactionServiceUrl cardServiceUrl:cardServiceUrl];
+    _zumoKit = [[ZumoKit alloc] initWithApiKey:apiKey apiUrl:apiUrl transactionServiceUrl:transactionServiceUrl cardServiceUrl:cardServiceUrl notificationServiceUrl:notificationServiceUrl];
     [_zumoKit addChangeListener:self];
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-zumo-kit",
-  "version": "3.0.0-beta.1",
+  "version": "3.0.0-beta.2",
   "description": "ZumoKit is a Wallet as a Service SDK",
   "keywords": [
     "zumo",
@@ -31,7 +31,7 @@
     "react-native": "^0.62.14"
   },
   "dependencies": {
-    "zumokit": "3.0.0-beta.1",
+    "zumokit": "3.0.0-beta.2",
     "decimal.js": "^10.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-zumo-kit",
-  "version": "2.4.1",
+  "version": "3.0.0-beta.1",
   "description": "ZumoKit is a Wallet as a Service SDK",
   "keywords": [
     "zumo",
@@ -31,7 +31,7 @@
     "react-native": "^0.62.14"
   },
   "dependencies": {
-    "zumokit": "2.4.1",
+    "zumokit": "3.0.0-beta.1",
     "decimal.js": "^10.2.0"
   },
   "devDependencies": {

--- a/src/ZumoKit.ts
+++ b/src/ZumoKit.ts
@@ -16,7 +16,6 @@ import {
   ExchangeRateJSON,
   ExchangeSettingJSON,
   TransactionFeeRateJSON,
-  Dictionary,
 } from 'zumokit/src/interfaces';
 import { Utils } from './Utils';
 import { User } from './User';
@@ -92,18 +91,25 @@ class ZumoKit {
   /**
    * Initializes ZumoKit SDK. Should only be called once.
    *
-   * @param apiKey          ZumoKit API key
-   * @param apiUrl          ZumoKit API URL
-   * @param txServiceUrl    ZumoKit Transaction Service URL
-   * @param cardServiceUrl  ZumoKit Card Service URL
+   * @param apiKey                 ZumoKit API key
+   * @param apiUrl                 ZumoKit API URL
+   * @param transactionServiceUrl  ZumoKit Transaction Service URL
+   * @param cardServiceUrl         ZumoKit Card Service URL
+   * @param notificationServiceUrl ZumoKit Notification Service URL
    */
-  init(apiKey: string, apiUrl: string, txServiceUrl: string, cardServiceUrl: string) {
+  init(
+    apiKey: string,
+    apiUrl: string,
+    txServiceUrl: string,
+    cardServiceUrl: string,
+    notificationServiceUrl: string
+  ) {
     this.emitter.addListener('AuxDataChanged', async () => {
       await this.updateAuxData();
       this.changeListeners.forEach((listener) => listener());
     });
 
-    RNZumoKit.init(apiKey, apiUrl, txServiceUrl, cardServiceUrl);
+    RNZumoKit.init(apiKey, apiUrl, txServiceUrl, cardServiceUrl, notificationServiceUrl);
   }
 
   /**
@@ -135,9 +141,7 @@ class ZumoKit {
    */
   getExchangeRate(fromCurrency: CurrencyCode, toCurrency: CurrencyCode): ExchangeRate | null {
     return Object.keys(this.exchangeRates).includes(fromCurrency)
-      ? ((this.exchangeRates[fromCurrency] as Dictionary<CurrencyCode, ExchangeRate>)[
-          toCurrency
-        ] as ExchangeRate)
+      ? this.exchangeRates[fromCurrency]![toCurrency]!
       : null;
   }
 
@@ -151,9 +155,7 @@ class ZumoKit {
    */
   getExchangeSetting(fromCurrency: CurrencyCode, toCurrency: CurrencyCode): ExchangeSetting | null {
     return Object.keys(this.exchangeSettings).includes(fromCurrency)
-      ? ((this.exchangeSettings[fromCurrency] as Dictionary<CurrencyCode, ExchangeSetting>)[
-          toCurrency
-        ] as ExchangeSetting)
+      ? this.exchangeSettings[fromCurrency]![toCurrency]!
       : null;
   }
 
@@ -166,7 +168,7 @@ class ZumoKit {
    */
   getTransactionFeeRate(currency: CurrencyCode): TransactionFeeRate | null {
     return Object.keys(this.transactionFeeRates).includes(currency)
-      ? (this.transactionFeeRates[currency] as TransactionFeeRate)
+      ? this.transactionFeeRates[currency]!
       : null;
   }
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1638,7 +1638,7 @@ write@1.0.3:
   dependencies:
     mkdirp "^0.5.1"
 
-zumokit@3.0.0-beta.1:
-  version "3.0.0-beta.1"
-  resolved "https://registry.yarnpkg.com/zumokit/-/zumokit-3.0.0-beta.1.tgz#3376198bb357a9c7368948c6014f30f205612515"
-  integrity sha512-YrJlqZ6M5jbVuzj3Z1Y+OLcnjXcao1QDZUR57GqRwgvi/cjPTHPZbNZPGPsWLoDVSXMBq6QiiP+D6ijFswMXPQ==
+zumokit@3.0.0-beta.2:
+  version "3.0.0-beta.2"
+  resolved "https://registry.yarnpkg.com/zumokit/-/zumokit-3.0.0-beta.2.tgz#18472faa4e8089e36bb4391ac2111b02094d2bb5"
+  integrity sha512-pBX/qIFpXRg84bywY22sDM8TWVpVfqzbHwmvKtgqGFw7IO71EZjdk3JBVO+FThlnLyYUovdmiw+GwBx7XxV8mw==

--- a/yarn.lock
+++ b/yarn.lock
@@ -1638,7 +1638,7 @@ write@1.0.3:
   dependencies:
     mkdirp "^0.5.1"
 
-zumokit@2.4.1:
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/zumokit/-/zumokit-2.4.1.tgz#f66f2561565d4d36437bbd70d906a7976b941c62"
-  integrity sha512-BFE6hyC+isFFSs1qeNhg0tQ84ARtXQH2EmcuXZ5cyB9iiS+tQSXx8gOMhNx9TuYykhnCToQuYDJvFITp6lzSww==
+zumokit@3.0.0-beta.1:
+  version "3.0.0-beta.1"
+  resolved "https://registry.yarnpkg.com/zumokit/-/zumokit-3.0.0-beta.1.tgz#3376198bb357a9c7368948c6014f30f205612515"
+  integrity sha512-YrJlqZ6M5jbVuzj3Z1Y+OLcnjXcao1QDZUR57GqRwgvi/cjPTHPZbNZPGPsWLoDVSXMBq6QiiP+D6ijFswMXPQ==


### PR DESCRIPTION
- Updates Android to AndroidX.
- Adds required notificationServiceUrl param to zumokit.init.
- Adds BSV support:

  - Two new accounts will be automatically created once user unlocks wallet - standard BSV main net and standard BSV test net accounts.
  - Transaction fees are already available, access them via zumokit.getTransactionFeeRate('BSV'),
  - Transactions can b composed via the existing wallet.composeTransaction method - use BSV account and BSV fees.
  - I have completely forgot about BSV address validation utility method. Will add it ASAP.