### PR TITLE
Release/3.2.0 beta.1

### DIFF
--- a/RNZumoKit.podspec
+++ b/RNZumoKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "RNZumoKit"
-  s.version      = "3.1.0"
+  s.version      = "3.2.0-beta.1"
   s.summary      = "RNZumoKit"
   s.description  = <<-DESC
                   RNZumoKit

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -42,5 +42,5 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar', '*.aar'])
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'org.java-websocket:Java-WebSocket:1.4.0'
-    implementation 'com.github.zumo:zumokit-android:3.1.0'
+    implementation 'com.github.zumo:zumokit-android:3.2.0-beta.1'
 }

--- a/android/src/main/java/com/zumokit/reactnative/RNZumoKitModule.java
+++ b/android/src/main/java/com/zumokit/reactnative/RNZumoKitModule.java
@@ -50,6 +50,7 @@ import money.zumo.zumokit.AccountCallback;
 import money.zumo.zumokit.TransactionFeeRate;
 import money.zumo.zumokit.ExchangeRate;
 import money.zumo.zumokit.Quote;
+import money.zumo.zumokit.QuoteCallback;
 import money.zumo.zumokit.exceptions.ZumoKitException;
 
 import java.math.BigDecimal;
@@ -1515,12 +1516,12 @@ public class RNZumoKitModule extends ReactContextBaseJavaModule {
     public static WritableMap mapQuote(Quote quote) {
         WritableMap mappedQuote = Arguments.createMap();
 
-        mappedQuote.putString("id", rate.getId());
-        mappedQuote.putInt("expireTime", rate.getExpireTime());
-        mappedQuote.putString("fromCurrency", rate.getFromCurrency());
-        mappedQuote.putString("toCurrency", rate.getToCurrency());
-        mappedQuote.putString("depositAmount", rate.getDepositAmount().toPlainString());
-        mappedQuote.putString("value", rate.getValue().toPlainString());
+        mappedQuote.putString("id", quote.getId());
+        mappedQuote.putInt("expireTime", quote.getExpireTime());
+        mappedQuote.putString("fromCurrency", quote.getFromCurrency());
+        mappedQuote.putString("toCurrency", quote.getToCurrency());
+        mappedQuote.putString("depositAmount", quote.getDepositAmount().toPlainString());
+        mappedQuote.putString("value", quote.getValue().toPlainString());
 
         return mappedQuote;
     }

--- a/ios/RNZumoKit.m
+++ b/ios/RNZumoKit.m
@@ -370,7 +370,7 @@ RCT_EXPORT_METHOD(unblockPin:(NSString *)cardId resolver:(RCTPromiseResolveBlock
     }
 }
 
-RCT_EXPORT_METHOD(getQuote:(NSString *)fromCurrency toCurrency:(NSString *)toCurrency (NSString *)depositAmount resolver:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseRejectBlock)reject)
+RCT_EXPORT_METHOD(getQuote:(NSString *)fromCurrency toCurrency:(NSString *)toCurrency depositAmount:(NSString *)depositAmount resolver:(RCTPromiseResolveBlock)resolve rejector:(RCTPromiseRejectBlock)reject)
 {
     @try {
         [_user getQuote:fromCurrency toCurrency:toCurrency depositAmount:[NSDecimalNumber decimalNumberWithString:depositAmount locale:[self decimalLocale]] completion:^(ZKQuote * _Nullable quote, NSError * _Nullable error) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-zumo-kit",
-  "version": "3.1.0",
+  "version": "3.2.0-beta.1",
   "description": "ZumoKit is a Wallet as a Service SDK",
   "keywords": [
     "zumo",
@@ -31,7 +31,7 @@
     "react-native": "^0.62.14"
   },
   "dependencies": {
-    "zumokit": "3.1.0",
+    "zumokit": "3.2.0-beta.1",
     "decimal.js": "^10.2.0"
   },
   "devDependencies": {

--- a/src/User.ts
+++ b/src/User.ts
@@ -1,6 +1,6 @@
 import { NativeModules, NativeEventEmitter } from 'react-native';
 import Decimal from 'decimal.js';
-import { Account, AccountFiatProperties, AccountDataSnapshot, Card } from 'zumokit/src/models';
+import { Account, AccountFiatProperties, AccountDataSnapshot, Card, Quote } from 'zumokit/src/models';
 import {
   AccountJSON,
   CurrencyCode,
@@ -276,7 +276,8 @@ export class User {
     toCurrency: CurrencyCode,
     depositAmount: Decimal
   ) {
-    return RNZumoKit.getQuote(fromCurrency, toCurrency, depositAmount.toString());
+    const json = await RNZumoKit.getQuote(fromCurrency, toCurrency, depositAmount.toString());
+    return new Quote(json);
   }
 
   /**

--- a/src/User.ts
+++ b/src/User.ts
@@ -1,4 +1,5 @@
 import { NativeModules, NativeEventEmitter } from 'react-native';
+import Decimal from 'decimal.js';
 import { Account, AccountFiatProperties, AccountDataSnapshot, Card } from 'zumokit/src/models';
 import {
   AccountJSON,
@@ -262,6 +263,20 @@ export class User {
    */
   async unblockPin(cardId: string): Promise<void> {
     return RNZumoKit.unblockPin(cardId);
+  }
+
+  /**
+   * Get exchange rate quote.
+   * @param fromCurrency  deposit currency code
+   * @param toCurrency    target currency code
+   * @param depositAmount deposit amount to be exchanged to target currency
+   */
+  async getQuote(
+    fromCurrency: CurrencyCode,
+    toCurrency: CurrencyCode,
+    depositAmount: Decimal
+  ) {
+    return RNZumoKit.getQuote(fromCurrency, toCurrency, depositAmount.toString());
   }
 
   /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1633,7 +1633,7 @@ write@1.0.3:
   dependencies:
     mkdirp "^0.5.1"
 
-zumokit@3.0.0-beta.5:
-  version "3.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/zumokit/-/zumokit-3.0.0-beta.5.tgz#295d523f98412c2240b3719d55a7f1e1cf52758f"
-  integrity sha512-9bvR3bPZUsDp3OuQy6Ss1O0LjYohs/LhntSF2O452OWrxHZXiiA8f/6ahXeq2cYmwl/sscnzG2dxUTx9oZmCCA==
+zumokit@3.2.0-beta.1:
+  version "3.2.0-beta.1"
+  resolved "https://registry.yarnpkg.com/zumokit/-/zumokit-3.2.0-beta.1.tgz#0be0f5281f3e462bd0a28818fe46dd826b0f6367"
+  integrity sha512-nesxQJcbkrBYXqqIOWbz0Poo+FKg+pgGPtDLuZ6NCoUXJUdCDWL6TepStQWUkFmNt8+N88h6fL2FBkTHsuEW2w==


### PR DESCRIPTION
BREAKING CHANGE: exchangeRate validTo property has been removed.

Adds support for user.getQuote method. Usage example:
```
const quote = await user.getQuote('BSV', 'BTC', new Decimal('0.005'));
```