### PR TITLE
Release/4.5.1

### DIFF
--- a/RNZumoKit.podspec
+++ b/RNZumoKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "RNZumoKit"
-  s.version      = "4.4.0"
+  s.version      = "4.5.0"
   s.summary      = "RNZumoKit"
   s.description  = <<-DESC
                   RNZumoKit

--- a/RNZumoKit.podspec
+++ b/RNZumoKit.podspec
@@ -2,7 +2,7 @@
 
 Pod::Spec.new do |s|
   s.name         = "RNZumoKit"
-  s.version      = "4.5.0"
+  s.version      = "4.5.1"
   s.summary      = "RNZumoKit"
   s.description  = <<-DESC
                   RNZumoKit

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,5 +40,5 @@ dependencies {
     implementation 'com.facebook.react:react-native:+'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'org.java-websocket:Java-WebSocket:1.4.0'
-    implementation 'money.zumo.zumokit:zumokit:4.4.0'
+    implementation 'money.zumo.zumokit:zumokit:4.5.0'
 }

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -40,5 +40,5 @@ dependencies {
     implementation 'com.facebook.react:react-native:+'
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'org.java-websocket:Java-WebSocket:1.4.0'
-    implementation 'money.zumo.zumokit:zumokit:4.5.0'
+    implementation 'money.zumo.zumokit:zumokit:4.5.1'
 }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-zumo-kit",
-  "version": "4.4.1",
+  "version": "4.5.0",
   "description": "ZumoKit is a Wallet as a Service SDK",
   "keywords": [
     "zumo",
@@ -31,7 +31,7 @@
     "react-native": "^0.62.14"
   },
   "dependencies": {
-    "zumokit": "4.4.0",
+    "zumokit": "4.5.0",
     "decimal.js": "^10.2.0"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-zumo-kit",
-  "version": "4.5.0",
+  "version": "4.5.1",
   "description": "ZumoKit is a Wallet as a Service SDK",
   "keywords": [
     "zumo",
@@ -31,7 +31,7 @@
     "react-native": "^0.62.14"
   },
   "dependencies": {
-    "zumokit": "4.5.0",
+    "zumokit": "4.5.1",
     "decimal.js": "^10.2.0"
   },
   "devDependencies": {

--- a/src/ZumoKit.ts
+++ b/src/ZumoKit.ts
@@ -91,6 +91,7 @@ class ZumoKit {
    * @param cardServiceUrl         ZumoKit Card Service URL
    * @param notificationServiceUrl ZumoKit Notification Service URL
    * @param exchangeServiceUrl     ZumoKit Exchange Service URL
+   * @param custodyServiceUrl      ZumoKit Custody Service URL
    */
   init(
     apiKey: string,
@@ -98,7 +99,8 @@ class ZumoKit {
     txServiceUrl: string,
     cardServiceUrl: string,
     notificationServiceUrl: string,
-    exchangeServiceUrl: string
+    exchangeServiceUrl: string,
+    custodyServiceUrl: string
   ) {
     this.emitter.addListener("AuxDataChanged", async () => {
       await this.updateAuxData();
@@ -111,7 +113,8 @@ class ZumoKit {
       txServiceUrl,
       cardServiceUrl,
       notificationServiceUrl,
-      exchangeServiceUrl
+      exchangeServiceUrl,
+      custodyServiceUrl
     );
   }
 


### PR DESCRIPTION
- Custody service URL is now required ZumoKit SDK constructor param
- Rework Custody Withdraw flows to get estimated fees from Custody Service
- Custody Withdraw is now a two step process, where first custody order is created and then executed
- Custody Order now exposes these additional props:
```ts
  /**  Custody order amount, null if not known yet. */
  amount: Decimal | null;

  /** Flag indicating if fees are included in order amount. */
  feeInAmount: boolean;

  /** Estimated custody order fees. */
  estimatedFees: Decimal | null;

  /** Actual custody order fees, null if not known yet. */
  fees: Decimal | null;
```